### PR TITLE
pkgs/crud: pass original object in pre delete hook

### DIFF
--- a/pkgs/crud/crud.go
+++ b/pkgs/crud/crud.go
@@ -193,7 +193,7 @@ func Delete(bctx bahamut.Context, m manipulate.Manipulator, obj elemental.Identi
 	bctx.SetOutputData(obj)
 
 	if cfg.preHook != nil {
-		if err := cfg.preHook(obj, nil); err != nil {
+		if err := cfg.preHook(obj, obj); err != nil {
 			return ErrPreWriteHook{Err: err}
 		}
 	}

--- a/pkgs/crud/crud_test.go
+++ b/pkgs/crud/crud_test.go
@@ -506,7 +506,7 @@ func TestDelete(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(preWriteHookCalled, ShouldBeTrue)
 			So(preWriteObj, ShouldNotBeNil)
-			So(preWriteOrig, ShouldBeNil)
+			So(preWriteOrig, ShouldNotBeNil)
 			So(postWriteHookCalled, ShouldBeTrue)
 			So(postWriteObj, ShouldNotBeNil)
 		})


### PR DESCRIPTION
The object is alread retrieved for classical delete operation, so there is no reason not to pass it to the pre hook. this patch makes sure it is passed on the pre hook for Delete operations