### PR TITLE
new/issue: add a way to waive the max validity of a token

### DIFF
--- a/cmd/a3s/conf.go
+++ b/cmd/a3s/conf.go
@@ -63,16 +63,17 @@ func newConf() Conf {
 
 // JWTConf holds the configuration related to jwt management.
 type JWTConf struct {
-	JWTAudience        string        `mapstructure:"jwt-audience" desc:"Default audience for delivered jwt"`
-	JWTCertPath        string        `mapstructure:"jwt-cert" desc:"Secret to use to sign the JWT" secret:"true" file:"true"`
-	JWTCookieDomain    string        `mapstructure:"jwt-cookie-domain" desc:"Defines the domain for the cookie"`
-	JWTCookiePolicy    string        `mapstructure:"jwt-cookie-policy" desc:"Define same site policy applied to token cookies" default:"strict" allowed:"strict,lax,none"`
-	JWTIssuer          string        `mapstructure:"jwt-issuer" desc:"Value used for issuer jwt field"`
-	JWTKeyPass         string        `mapstructure:"jwt-key-pass" desc:"JWT certificate key password" secret:"true" file:"true"`
-	JWTKeyPath         string        `mapstructure:"jwt-key" desc:"Path to the JWT certificate key pem file" secret:"true" file:"true"`
-	JWTTrustedIssuers  []string      `mapstructure:"jwt-trusted-issuer" desc:"List of externally trusted issuers"`
-	JWTDefaultValidity time.Duration `mapstructure:"jwt-default-validity" desc:"Default duration of the validity of the issued tokens" default:"24h"`
-	JWTMaxValidity     time.Duration `mapstructure:"jwt-max-validity" desc:"Maximum duration of the validity of the issued tokens" default:"720h"`
+	JWTAudience            string        `mapstructure:"jwt-audience" desc:"Default audience for delivered jwt"`
+	JWTCertPath            string        `mapstructure:"jwt-cert" desc:"Secret to use to sign the JWT" secret:"true" file:"true"`
+	JWTCookieDomain        string        `mapstructure:"jwt-cookie-domain" desc:"Defines the domain for the cookie"`
+	JWTCookiePolicy        string        `mapstructure:"jwt-cookie-policy" desc:"Define same site policy applied to token cookies" default:"strict" allowed:"strict,lax,none"`
+	JWTIssuer              string        `mapstructure:"jwt-issuer" desc:"Value used for issuer jwt field"`
+	JWTKeyPass             string        `mapstructure:"jwt-key-pass" desc:"JWT certificate key password" secret:"true" file:"true"`
+	JWTKeyPath             string        `mapstructure:"jwt-key" desc:"Path to the JWT certificate key pem file" secret:"true" file:"true"`
+	JWTTrustedIssuers      []string      `mapstructure:"jwt-trusted-issuer" desc:"List of externally trusted issuers"`
+	JWTDefaultValidity     time.Duration `mapstructure:"jwt-default-validity" desc:"Default duration of the validity of the issued tokens" default:"24h"`
+	JWTMaxValidity         time.Duration `mapstructure:"jwt-max-validity" desc:"Maximum duration of the validity of the issued tokens" default:"720h"`
+	JWTWaiveValiditySecret string        `mapstructure:"jwt-waive-validity-secret" desc:"The secret to use to waive max validity enforcement" file:"true" secret:"true"`
 
 	jwtKey  crypto.PrivateKey
 	jwtCert *x509.Certificate

--- a/cmd/a3s/main.go
+++ b/cmd/a3s/main.go
@@ -173,6 +173,9 @@ func main() {
 		"iss", cfg.JWT.JWTIssuer,
 		"aud", cfg.JWT.JWTAudience,
 	)
+	if cfg.JWT.JWTWaiveValiditySecret != "" {
+		slog.Info("JWT max validity waive secret configured")
+	}
 
 	jwks := token.NewJWKS()
 	if err := jwks.AppendWithPrivate(jwtCert, jwtKey); err != nil {
@@ -414,6 +417,7 @@ func main() {
 			cfg.JWT.JWTMaxValidity,
 			cfg.JWT.JWTIssuer,
 			cfg.JWT.JWTAudience,
+			cfg.JWT.JWTWaiveValiditySecret,
 			cookiePolicy,
 			cookieDomain,
 			cfg.MTLSHeaderConf.Enabled,

--- a/internal/issuer/a3sissuer/a3s_test.go
+++ b/internal/issuer/a3sissuer/a3s_test.go
@@ -61,7 +61,7 @@ func TestFromToken(t *testing.T) {
 	Convey("Using a token with an bad restrictions", t, func() {
 		token := `eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZWFsbSI6IlZpbmNlIiwiZGF0YSI6eyJhY2NvdW50IjoiYXBvbXV4IiwiZW1haWwiOiJhZG1pbkBhcG9tdXguY29tIiwiaWQiOiI1ZTFjZjNlZmEzNzAwMzhmYWY3Zjg3NzciLCJvcmdhbml6YXRpb24iOiJhcG9tdXgiLCJyZWFsbSI6InZpbmNlIiwic3ViamVjdCI6ImFwb211eCJ9LCJyZXN0cmljdGlvbnMiOnsibmV0d29ya3MiOiIxMjcuMC4wLjEvMzIifSwiZXhwIjoxNTkwMDQzMjA1LCJpYXQiOjE1ODk5NTMyMDUsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0OjQ0NDMiLCJzdWIiOiJhcG9tdXgifQ.dIsnGMSEy961FqXgJH-TBVw8_9VrzH_j4xcQJG4JY0--ekwNuMpLr0CyOJFj_XFuVsY-ZS8Lwj5yJCYHv7TS8Q`
 		c := newA3SIssuer()
-		err := c.fromToken(token, keychain, "", nil, 0)
+		err := c.fromToken(token, keychain, "", nil, 0, false)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, `unable to compute restrictions: unable to compute authz restrictions from token: json: cannot unmarshal string into Go struct field Restrictions.restrictions.networks of type []string`)
 	})
@@ -69,7 +69,7 @@ func TestFromToken(t *testing.T) {
 	Convey("Using a token that is missing kid", t, func() {
 		token := `eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZWFsbSI6IlZpbmNlIiwiZGF0YSI6eyJhY2NvdW50IjoiYXBvbXV4IiwiZW1haWwiOiJhZG1pbkBhcG9tdXguY29tIiwiaWQiOiI1ZTFjZjNlZmEzNzAwMzhmYWY3Zjg3NzciLCJvcmdhbml6YXRpb24iOiJhcG9tdXgiLCJyZWFsbSI6InZpbmNlIiwic3ViamVjdCI6ImFwb211eCJ9LCJyZXN0cmljdGlvbnMiOnt9LCJleHAiOjE1OTAzMDQzNDgsImlhdCI6MTU5MDIxNDM0OCwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6NDQ0MyIsInN1YiI6ImFwb211eCJ9.7TZEEG-M-Ed-pKTzEGVZnKKZ1fvG0P7kN-VIKnVn_4TkTR2PX0EaToNZViGgcIs6pYXm7SByzjMl63ZiriSYkg`
 		c := newA3SIssuer()
-		err := c.fromToken(token, keychain, "", nil, 0)
+		err := c.fromToken(token, keychain, "", nil, 0, false)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, `unable to parse input token: unable to parse jwt: token has no KID in its header`)
 	})
@@ -82,7 +82,7 @@ func TestFromToken(t *testing.T) {
 
 		token, _ := mc.JWT(key, kid, "iss", jwt.ClaimStrings{"aud"}, time.Time{}, nil)
 		c := newA3SIssuer()
-		err := c.fromToken(token, keychain, "iss", jwt.ClaimStrings{"aud"}, 0)
+		err := c.fromToken(token, keychain, "iss", jwt.ClaimStrings{"aud"}, 0, false)
 
 		So(err, ShouldBeNil)
 		So(c.token.Restrictions, ShouldBeNil)
@@ -96,7 +96,7 @@ func TestFromToken(t *testing.T) {
 
 		token, _ := mc.JWT(key, kid, "iss", jwt.ClaimStrings{"aud1", "aud2"}, time.Time{}, nil)
 		c := newA3SIssuer()
-		err := c.fromToken(token, keychain, "iss", jwt.ClaimStrings{"aud1", "aud2"}, 0)
+		err := c.fromToken(token, keychain, "iss", jwt.ClaimStrings{"aud1", "aud2"}, 0, false)
 
 		So(err, ShouldBeNil)
 		So(c.token.Restrictions, ShouldBeNil)
@@ -110,7 +110,7 @@ func TestFromToken(t *testing.T) {
 
 		token, _ := mc.JWT(key, kid, "iss", jwt.ClaimStrings{"aud1", "aud2"}, time.Time{}, nil)
 		c := newA3SIssuer()
-		err := c.fromToken(token, keychain, "iss", jwt.ClaimStrings{"aud2"}, 0)
+		err := c.fromToken(token, keychain, "iss", jwt.ClaimStrings{"aud2"}, 0, false)
 
 		So(err, ShouldBeNil)
 		So(c.token.Restrictions, ShouldBeNil)
@@ -124,7 +124,7 @@ func TestFromToken(t *testing.T) {
 
 		token, _ := mc.JWT(key, kid, "iss", jwt.ClaimStrings{"aud1", "aud2"}, time.Time{}, nil)
 		c := newA3SIssuer()
-		err := c.fromToken(token, keychain, "iss", jwt.ClaimStrings{"aud2", "aud3"}, 0)
+		err := c.fromToken(token, keychain, "iss", jwt.ClaimStrings{"aud2", "aud3"}, 0, false)
 
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "unable to parse input token: requested audience 'aud3' is not declared in initial token")
@@ -138,7 +138,7 @@ func TestFromToken(t *testing.T) {
 
 		token, _ := mc.JWT(key, kid, "iss", jwt.ClaimStrings{"aud1", "aud2"}, time.Time{}, nil)
 		c := newA3SIssuer()
-		err := c.fromToken(token, keychain, "iss", nil, 0)
+		err := c.fromToken(token, keychain, "iss", nil, 0, false)
 
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "unable to parse input token: you cannot request a token with no audience from a token that has one")

--- a/pkgs/api/doc/documentation.md
+++ b/pkgs/api/doc/documentation.md
@@ -241,6 +241,13 @@ Type: `string`
 
 The original token.
 
+##### `waiveValiditySecret`
+
+Type: `string`
+
+If A3S has been started --jwt-waive-validity-secret and this propery matches it,
+no validity limit will be enforced.
+
 ### IssueAWS
 
 Additional issuing information for AWS STS token source.

--- a/pkgs/api/issuea3s.go
+++ b/pkgs/api/issuea3s.go
@@ -16,6 +16,10 @@ type IssueA3S struct {
 	// The original token.
 	Token string `json:"token" msgpack:"token" bson:"-" mapstructure:"token,omitempty"`
 
+	// If A3S has been started --jwt-waive-validity-secret and this propery matches it,
+	// no validity limit will be enforced.
+	WaiveValiditySecret string `json:"waiveValiditySecret,omitempty" msgpack:"waiveValiditySecret,omitempty" bson:"-" mapstructure:"waiveValiditySecret,omitempty"`
+
 	ModelVersion int `json:"-" msgpack:"-" bson:"_modelversion"`
 }
 
@@ -132,6 +136,8 @@ func (o *IssueA3S) ValueForAttribute(name string) any {
 	switch name {
 	case "token":
 		return o.Token
+	case "waiveValiditySecret":
+		return o.WaiveValiditySecret
 	}
 
 	return nil
@@ -148,6 +154,16 @@ var IssueA3SAttributesMap = map[string]elemental.AttributeSpecification{
 		Required:       true,
 		Type:           "string",
 	},
+	"WaiveValiditySecret": {
+		AllowedChoices: []string{},
+		ConvertedName:  "WaiveValiditySecret",
+		Description: `If A3S has been started --jwt-waive-validity-secret and this propery matches it,
+no validity limit will be enforced.`,
+		Exposed: true,
+		Name:    "waiveValiditySecret",
+		Secret:  true,
+		Type:    "string",
+	},
 }
 
 // IssueA3SLowerCaseAttributesMap represents the map of attribute for IssueA3S.
@@ -160,6 +176,16 @@ var IssueA3SLowerCaseAttributesMap = map[string]elemental.AttributeSpecification
 		Name:           "token",
 		Required:       true,
 		Type:           "string",
+	},
+	"waivevaliditysecret": {
+		AllowedChoices: []string{},
+		ConvertedName:  "WaiveValiditySecret",
+		Description: `If A3S has been started --jwt-waive-validity-secret and this propery matches it,
+no validity limit will be enforced.`,
+		Exposed: true,
+		Name:    "waiveValiditySecret",
+		Secret:  true,
+		Type:    "string",
 	},
 }
 

--- a/pkgs/api/openapi3/toplevel
+++ b/pkgs/api/openapi3/toplevel
@@ -626,6 +626,10 @@
             "description": "The original token.",
             "example": "valid.jwt.token",
             "type": "string"
+          },
+          "waiveValiditySecret": {
+            "description": "If A3S has been started --jwt-waive-validity-secret and this propery matches it,\nno validity limit will be enforced.",
+            "type": "string"
           }
         },
         "required": [

--- a/pkgs/api/specs/+issuea3s.spec
+++ b/pkgs/api/specs/+issuea3s.spec
@@ -3,6 +3,7 @@ model:
   rest_name: issuea3s
   resource_name: issuea3s
   entity_name: IssueA3S
+  friendly_name: IssueA3S
   package: a3s
   group: authn/issue
   description: Additional issuing information for A3S token source.
@@ -12,8 +13,19 @@ model:
 attributes:
   v1:
   - name: token
+    friendly_name: Token
     description: The original token.
     type: string
     exposed: true
     required: true
     example_value: valid.jwt.token
+
+  - name: waiveValiditySecret
+    friendly_name: Waive Validity Secret
+    description: |-
+      If A3S has been started --jwt-waive-validity-secret and this propery matches it,
+      no validity limit will be enforced.
+    type: string
+    exposed: true
+    secret: true
+    omit_empty: true


### PR DESCRIPTION
This patch adds a way to pass a secret to a3s to waive the max validity check. Starting a3s with --jwt-waive-validity-secret will allow the callers of issue to set issue.InputA3S.WaiveValiditySecret. If it matches the flag, then max validity check will be waived. This is only for use by a trusted service from a trusted platform.