### PR TITLE
new: add audit to track actions on APIs

### DIFF
--- a/cmd/a3s/conf.go
+++ b/cmd/a3s/conf.go
@@ -20,16 +20,17 @@ var (
 
 // Conf holds the main configuration flags.
 type Conf struct {
-	BinaryModifier     string `mapstructure:"binary-modifier" desc:"Path to modifier binary. If set, binary-modifier-sha256 must be set"`
-	BinaryModifierHash string `mapstructure:"binary-modifier-sha256" desc:"Sha256 hash of the binary-modifier"`
-	Init               bool   `mapstructure:"init" desc:"If set, initialize the root permissions using the CAs passed in --init-root-ca and --init-platform-ca"`
-	InitContinue       bool   `mapstructure:"init-continue" desc:"Continues normal boot after init."`
-	InitDB             bool   `mapstructure:"init-db" desc:"If set, initialize the database using the mongo config passed in and init-db-username"`
-	InitDBUsername     string `mapstructure:"init-db-username" desc:"If init-db is set, this will define the username to use on db initialization" default:"CN=a3s,OU=root,O=system"`
-	InitData           string `mapstructure:"init-data" desc:"Path to an import file containing initial provisionning data"`
-	InitPlatformCAPath string `mapstructure:"init-platform-ca" desc:"Path to the platform CA to use to initialize platform permissions"`
-	InitRootUserCAPath string `mapstructure:"init-root-ca" desc:"Path to the root CA to use to initialize root permissions"`
-	PluginModifier     string `mapstructure:"plugin-modifier" desc:"Path to a go plugin implemeting the plugin.Modifier interface"`
+	AuditedIdentities  []string `mapstructure:"audited-identities" desc:"Identities that will be tracked for audit purposes" default:"issue"`
+	BinaryModifier     string   `mapstructure:"binary-modifier" desc:"Path to modifier binary. If set, binary-modifier-sha256 must be set"`
+	BinaryModifierHash string   `mapstructure:"binary-modifier-sha256" desc:"Sha256 hash of the binary-modifier"`
+	Init               bool     `mapstructure:"init" desc:"If set, initialize the root permissions using the CAs passed in --init-root-ca and --init-platform-ca"`
+	InitContinue       bool     `mapstructure:"init-continue" desc:"Continues normal boot after init."`
+	InitDB             bool     `mapstructure:"init-db" desc:"If set, initialize the database using the mongo config passed in and init-db-username"`
+	InitDBUsername     string   `mapstructure:"init-db-username" desc:"If init-db is set, this will define the username to use on db initialization" default:"CN=a3s,OU=root,O=system"`
+	InitData           string   `mapstructure:"init-data" desc:"Path to an import file containing initial provisionning data"`
+	InitPlatformCAPath string   `mapstructure:"init-platform-ca" desc:"Path to the platform CA to use to initialize platform permissions"`
+	InitRootUserCAPath string   `mapstructure:"init-root-ca" desc:"Path to the root CA to use to initialize root permissions"`
+	PluginModifier     string   `mapstructure:"plugin-modifier" desc:"Path to a go plugin implemeting the plugin.Modifier interface"`
 
 	JWT JWTConf `mapstructure:",squash"`
 

--- a/pkgs/auditor/auditor.go
+++ b/pkgs/auditor/auditor.go
@@ -1,0 +1,91 @@
+package auditor
+
+import (
+	"log/slog"
+	"slices"
+
+	"go.acuvity.ai/a3s/pkgs/notification"
+	"go.acuvity.ai/bahamut"
+	"go.acuvity.ai/elemental"
+)
+
+// Constants for notification topics.
+const (
+	NotificationAudit = "notifications.audit"
+)
+
+// AuditMessage outlines what an audit notification will contain.
+type AuditMessage struct {
+	Operation elemental.Operation
+	Identity  elemental.Identity
+	Namespace string
+	ClaimsMap map[string]string
+	Error     string
+}
+
+// Auditor outlines what an auditor contains.
+type Auditor struct {
+	pubsub            bahamut.PubSubClient
+	trackedIdentities map[elemental.Identity]*TrackedIdentity
+
+	bahamut.Auditer
+}
+
+// TrackedIdentity contains the indetity we want to track across the specified
+// operations. If operations are empty it will track all actions.
+type TrackedIdentity struct {
+	Identity   elemental.Identity
+	Operations []elemental.Operation
+}
+
+// NewAuditor returns a new Auditor.
+func NewAuditor(pubsub bahamut.PubSubClient, identities []*TrackedIdentity) *Auditor {
+
+	trackedIdentities := map[elemental.Identity]*TrackedIdentity{}
+
+	for _, trackedIdentity := range identities {
+		trackedIdentities[trackedIdentity.Identity] = trackedIdentity
+	}
+
+	return &Auditor{
+		pubsub:            pubsub,
+		trackedIdentities: trackedIdentities,
+	}
+}
+
+// Audit pushes the audit message to nats.
+func (a *Auditor) Audit(bctx bahamut.Context, err error) {
+
+	if len(a.trackedIdentities) != 0 {
+		trackedIdentity, ok := a.trackedIdentities[bctx.Request().Identity]
+		if !ok {
+			return
+		}
+
+		if len(trackedIdentity.Operations) != 0 && !slices.Contains(trackedIdentity.Operations, bctx.Request().Operation) {
+			return
+		}
+	}
+
+	msg := &AuditMessage{
+		Operation: bctx.Request().Operation,
+		Identity:  bctx.Request().Identity,
+		Namespace: bctx.Request().Namespace,
+		ClaimsMap: bctx.ClaimsMap(),
+	}
+
+	if err != nil {
+		msg.Error = err.Error()
+	}
+
+	if err = notification.Publish(
+		a.pubsub,
+		NotificationAudit,
+		&notification.Message{
+			Type: string(msg.Operation),
+			Data: msg,
+		},
+	); err != nil {
+		slog.Error("Issue publishing audit message", err)
+	}
+}

--- a/pkgs/auditor/auditor_test.go
+++ b/pkgs/auditor/auditor_test.go
@@ -1,0 +1,224 @@
+package auditor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.acuvity.ai/a3s/pkgs/notification"
+	"go.acuvity.ai/bahamut"
+	"go.acuvity.ai/elemental"
+)
+
+func TestAudit(t *testing.T) {
+
+	Convey("Given I have a pubsub client", t, func() {
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		pubsub := bahamut.NewLocalPubSubClient()
+		_ = pubsub.Connect(ctx)
+
+		recvmsg := make(chan *notification.Message, 2)
+		h := func(msg *notification.Message) {
+			recvmsg <- msg
+		}
+
+		Convey("When an allowed request is audited, all identities", func() {
+
+			audit := NewAuditor(pubsub, nil)
+
+			notification.Subscribe(ctx, pubsub, NotificationAudit, h)
+
+			bctx := bahamut.NewContext(ctx,
+				&elemental.Request{
+					Operation: elemental.OperationCreate,
+					Identity:  elemental.MakeIdentity("testName", "testCategory"),
+					Namespace: "testNamespace",
+				},
+			)
+			bctx.SetClaims([]string{"something=else", "a=token"})
+
+			audit.Audit(bctx, nil)
+
+			var msg *notification.Message
+			select {
+			case msg = <-recvmsg:
+			case <-time.After(300 * time.Millisecond):
+				panic("test did not get response in time")
+			}
+
+			So(msg, ShouldNotBeNil)
+			So(msg.Type, ShouldEqual, string(elemental.OperationCreate))
+
+			var sentMsg *AuditMessage
+			So(mapstructure.Decode(msg.Data, &sentMsg), ShouldBeNil)
+
+			So(sentMsg, ShouldResemble, &AuditMessage{
+				Operation: elemental.OperationCreate,
+				Identity:  elemental.MakeIdentity("testName", "testCategory"),
+				Namespace: "testNamespace",
+				ClaimsMap: map[string]string{
+					"something": "else",
+					"a":         "token",
+				},
+			})
+		})
+
+		Convey("When an allowed request is audited, tracked identity", func() {
+
+			audit := NewAuditor(pubsub, []*TrackedIdentity{
+				{
+					Identity:   elemental.MakeIdentity("testName", "testCategory"),
+					Operations: []elemental.Operation{elemental.OperationCreate},
+				},
+			})
+
+			notification.Subscribe(ctx, pubsub, NotificationAudit, h)
+
+			bctx := bahamut.NewContext(ctx,
+				&elemental.Request{
+					Operation: elemental.OperationCreate,
+					Identity:  elemental.MakeIdentity("testName", "testCategory"),
+					Namespace: "testNamespace",
+				},
+			)
+			bctx.SetClaims([]string{"something=else", "a=token"})
+
+			audit.Audit(bctx, nil)
+
+			var msg *notification.Message
+			select {
+			case msg = <-recvmsg:
+			case <-time.After(300 * time.Millisecond):
+				panic("test did not get response in time")
+			}
+
+			So(msg, ShouldNotBeNil)
+			So(msg.Type, ShouldEqual, string(elemental.OperationCreate))
+
+			var sentMsg *AuditMessage
+			So(mapstructure.Decode(msg.Data, &sentMsg), ShouldBeNil)
+
+			So(sentMsg, ShouldResemble, &AuditMessage{
+				Operation: elemental.OperationCreate,
+				Identity:  elemental.MakeIdentity("testName", "testCategory"),
+				Namespace: "testNamespace",
+				ClaimsMap: map[string]string{
+					"something": "else",
+					"a":         "token",
+				},
+			})
+		})
+
+		Convey("When a denied request is audited", func() {
+
+			audit := NewAuditor(pubsub, nil)
+
+			notification.Subscribe(ctx, pubsub, NotificationAudit, h)
+
+			bctx := bahamut.NewContext(ctx,
+				&elemental.Request{
+					Operation: elemental.OperationCreate,
+					Identity:  elemental.MakeIdentity("testName", "testCategory"),
+					Namespace: "testNamespace",
+				},
+			)
+			bctx.SetClaims([]string{"something=else", "a=token"})
+
+			err := fmt.Errorf("boom")
+
+			audit.Audit(bctx, err)
+
+			var msg *notification.Message
+			select {
+			case msg = <-recvmsg:
+			case <-time.After(300 * time.Millisecond):
+				panic("test did not get response in time")
+			}
+
+			So(msg, ShouldNotBeNil)
+			So(msg.Type, ShouldEqual, string(elemental.OperationCreate))
+
+			var sentMsg *AuditMessage
+			So(mapstructure.Decode(msg.Data, &sentMsg), ShouldBeNil)
+
+			So(sentMsg, ShouldResemble, &AuditMessage{
+				Operation: elemental.OperationCreate,
+				Identity:  elemental.MakeIdentity("testName", "testCategory"),
+				Namespace: "testNamespace",
+				ClaimsMap: map[string]string{
+					"something": "else",
+					"a":         "token",
+				},
+				Error: err.Error(),
+			})
+		})
+
+		Convey("When a request identity is ignored", func() {
+
+			audit := NewAuditor(pubsub, []*TrackedIdentity{
+				{
+					Identity:   elemental.MakeIdentity("testName2", "testCategory2"),
+					Operations: []elemental.Operation{elemental.OperationCreate},
+				},
+			})
+
+			notification.Subscribe(ctx, pubsub, NotificationAudit, h)
+
+			bctx := bahamut.NewContext(ctx,
+				&elemental.Request{
+					Operation: elemental.OperationCreate,
+					Identity:  elemental.MakeIdentity("testName", "testCategory"),
+					Namespace: "testNamespace",
+				},
+			)
+			bctx.SetClaims([]string{"something=else", "a=token"})
+
+			audit.Audit(bctx, nil)
+
+			var msg *notification.Message
+			select {
+			case msg = <-recvmsg:
+			case <-time.After(300 * time.Millisecond):
+			}
+
+			So(msg, ShouldBeNil)
+		})
+
+		Convey("When a request operation is ignored", func() {
+
+			audit := NewAuditor(pubsub, []*TrackedIdentity{
+				{
+					Identity:   elemental.MakeIdentity("testName", "testCategory"),
+					Operations: []elemental.Operation{elemental.OperationDelete},
+				},
+			})
+
+			notification.Subscribe(ctx, pubsub, NotificationAudit, h)
+
+			bctx := bahamut.NewContext(ctx,
+				&elemental.Request{
+					Operation: elemental.OperationCreate,
+					Identity:  elemental.MakeIdentity("testName", "testCategory"),
+					Namespace: "testNamespace",
+				},
+			)
+			bctx.SetClaims([]string{"something=else", "a=token"})
+
+			audit.Audit(bctx, nil)
+
+			var msg *notification.Message
+			select {
+			case msg = <-recvmsg:
+			case <-time.After(300 * time.Millisecond):
+			}
+
+			So(msg, ShouldBeNil)
+		})
+	})
+}


### PR DESCRIPTION
#### Description
This PR provides a way to audit a3s identities by a configurable parameter (default is `issue`). This will allow us to track login attempts among other identities in the future.

> Fixes: https://github.com/acuvity/acuvity/issues/281