### PR TITLE
build: align cov threshold with new version

### DIFF
--- a/.covignore
+++ b/.covignore
@@ -1,3 +1,6 @@
-**/pkgs/api/*
+**/cmd/*
 **/example/*
+**/pkgs/api/*
+**/pkgs/cli/*
+**/ui/*
 docs

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -45,5 +45,5 @@ jobs:
         with:
           main_branch: master
           cov_file: unit_coverage.out
-          cov_threshold: "75"
+          cov_threshold: "64"
           cov_mode: coverage


### PR DESCRIPTION
#### Description
The new version of cov is far more inclusive and captures more files in the repo. This means more needs to be ignored and the threshold needs to be loosened to have a passable condition once again