### PR TITLE
issue: set context claims when we figure them out

### DIFF
--- a/internal/processors/issue.go
+++ b/internal/processors/issue.go
@@ -180,6 +180,8 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 	idt := issuer.Issue()
 	idt.Opaque = req.Opaque
 
+	bctx.SetClaims(idt.Identity)
+
 	if err := idt.Restrict(permissions.Restrictions{
 		Namespace:   req.RestrictedNamespace,
 		Networks:    req.RestrictedNetworks,


### PR DESCRIPTION
#### Description
Setting the claims in the context will allow us to easily refer to them in the auditor which looks at `bctx.ClaimsMap()`.