### PR TITLE
issue: log issuer identity claims to metadata for audit purposes

### DIFF
--- a/internal/processors/issue.go
+++ b/internal/processors/issue.go
@@ -26,6 +26,7 @@ import (
 	"go.acuvity.ai/a3s/internal/oidcceremony"
 	"go.acuvity.ai/a3s/internal/samlceremony"
 	"go.acuvity.ai/a3s/pkgs/api"
+	"go.acuvity.ai/a3s/pkgs/auditor"
 	"go.acuvity.ai/a3s/pkgs/modifier/binary"
 	"go.acuvity.ai/a3s/pkgs/modifier/plugin"
 	"go.acuvity.ai/a3s/pkgs/permissions"
@@ -179,6 +180,10 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 
 	idt := issuer.Issue()
 	idt.Opaque = req.Opaque
+
+	defer func() {
+		bctx.SetMetadata(auditor.MetadataKeyAudit, idt.Identity)
+	}()
 
 	if err := idt.Restrict(permissions.Restrictions{
 		Namespace:   req.RestrictedNamespace,


### PR DESCRIPTION
#### Description
For private APIs, we need a token to access them which sets to claims in the context. For public endpoints like `/issue` we need to track these claims through the Metadata of the context (so that it is opaque and doesn't cause confusion). The audit function will now check if this is set and place the contents into the claims map if so.

`SetMetadata` is put into a defer so we get insight once we have an issuer regardless of error or success paths later in the function. The defer allows the claims to capture all identity claims set at the moment of exit (eg. `idt.JWT(...)` adds extra claims later on after a couple error paths).

> Fixes: https://github.com/acuvity/acuvity/issues/308