### PR TITLE
a3s: allow client to expose public resources

### DIFF
--- a/pkgs/bootstrap/clients.go
+++ b/pkgs/bootstrap/clients.go
@@ -210,6 +210,7 @@ func MakeA3SRemoteAuth(
 	m manipulate.Manipulator,
 	requiredIssuer string,
 	requiredAudience string,
+	publicResources ...string,
 ) (*authenticator.Authenticator, authorizer.Authorizer, error) {
 
 	var jwks *token.JWKS
@@ -234,11 +235,13 @@ func MakeA3SRemoteAuth(
 			jwks,
 			requiredIssuer,
 			requiredAudience,
+			authenticator.OptionIgnoredResources(publicResources...),
 		),
 		authorizer.NewRemote(
 			ctx,
 			m,
 			permissions.NewRemoteRetriever(m),
+			authorizer.OptionIgnoredResources(publicResources...),
 		),
 		nil
 }


### PR DESCRIPTION
Allow clients created with `MakeA3SRemoteAuth` to pass a list of public resources