### PR TITLE
build: move to golang v1.23.x

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.22"
+          - "1.23"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
#### Description
Golang had a major release August 13th here: https://go.dev/doc/go1.23 This bumps our builds to using it.