### PR TITLE
saml: support url for IDP metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,8 @@ require (
 	golang.org/x/term v0.21.0
 )
 
+require github.com/karlseguin/ccache/v3 v3.0.6
+
 require (
 	cloud.google.com/go/compute v1.23.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karlseguin/ccache/v2 v2.0.8 h1:lT38cE//uyf6KcFok0rlgXtGFBWxkI6h/qg4tbFyDnA=
 github.com/karlseguin/ccache/v2 v2.0.8/go.mod h1:2BDThcfQMf/c0jnZowt16eW405XIqZPavt+HoYEtcxQ=
+github.com/karlseguin/ccache/v3 v3.0.6 h1:6wC04CXSdptebuSUBgsQixNrrRMUdimtwmjlJUpCf/4=
+github.com/karlseguin/ccache/v3 v3.0.6/go.mod h1:b0qfdUOHl4vJgKFQN41paXIdBb3acAtyX2uWrBAZs1w=
 github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003 h1:vJ0Snvo+SLMY72r5J4sEfkuE7AFbixEP2qRbEcum/wA=
 github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/internal/issuer/samlissuer/saml_test.go
+++ b/internal/issuer/samlissuer/saml_test.go
@@ -203,7 +203,7 @@ func Test_computeSAMLAssertion(t *testing.T) {
 					},
 					map[string]struct{}{},
 					map[string]struct{}{
-						"name": struct{}{},
+						"name": {},
 					},
 				}
 			},
@@ -241,7 +241,7 @@ func Test_computeSAMLAssertion(t *testing.T) {
 						},
 					},
 					map[string]struct{}{
-						"name": struct{}{},
+						"name": {},
 					},
 					map[string]struct{}{},
 				}
@@ -298,8 +298,8 @@ func Test_computeSAMLInclusion(t *testing.T) {
 					},
 				}
 			},
-			map[string]struct{}{"a": struct{}{}},
-			map[string]struct{}{"b": struct{}{}},
+			map[string]struct{}{"a": {}},
+			map[string]struct{}{"b": {}},
 		},
 	}
 

--- a/pkgs/api/custom_validations.go
+++ b/pkgs/api/custom_validations.go
@@ -207,7 +207,23 @@ func ValidateURL(attribute string, u string) error {
 // ValidateSAMLSource validates the given SAMLSource.
 func ValidateSAMLSource(source *SAMLSource) error {
 
-	if source.IDPMetadata != "" {
+	if source.IDPMetadata != "" && source.IDPMetadataURL != "" {
+		return makeErr("IDPMedata", "If IDPMetadataURL is set, you cannot set IDPMetadata")
+	}
+
+	if source.IDPMetadata != "" || source.IDPMetadataURL != "" {
+		source.IDPURL = ""
+		source.IDPCertificate = ""
+		source.IDPIssuer = ""
+
+		if source.IDPMetadata != "" {
+			source.IDPMetadataURL = ""
+		}
+
+		if source.IDPMetadataURL != "" {
+			source.IDPMetadata = ""
+		}
+
 		return nil
 	}
 

--- a/pkgs/api/custom_validations_test.go
+++ b/pkgs/api/custom_validations_test.go
@@ -1136,6 +1136,31 @@ func TestValidateSAMLSource(t *testing.T) {
 		},
 
 		{
+			"metadata URL is set",
+			func(*testing.T) args {
+				return args{
+					&SAMLSource{
+						IDPMetadataURL: "https://coucou.com",
+					},
+				}
+			},
+			false,
+			nil,
+		},
+		{
+			"metadata URL is set",
+			func(*testing.T) args {
+				return args{
+					&SAMLSource{
+						IDPMetadataURL: "https://coucou.com",
+						IDPMetadata:    "coucou",
+					},
+				}
+			},
+			true,
+			nil,
+		},
+		{
 			"metadata is set",
 			func(*testing.T) args {
 				return args{
@@ -1147,6 +1172,7 @@ func TestValidateSAMLSource(t *testing.T) {
 			false,
 			nil,
 		},
+
 		{
 			"metadata is not set but all other fields are",
 			func(*testing.T) args {

--- a/pkgs/api/doc/documentation.md
+++ b/pkgs/api/doc/documentation.md
@@ -1605,7 +1605,15 @@ Type: `string`
 
 Pass some XML data containing the IDP metadata that can be used for automatic
 configuration. If you pass this attribute, every other one will be overwritten
-with the data contained in the metadata file.
+with the data contained in the metadata file, but it does not take precendence
+over IDPMetadataURL.
+
+##### `IDPMetadataURL`
+
+Type: `string`
+
+The URL where to fetch the IDPMetadata. If this is set, all other IDP fields are
+ignored and the metadata will be retrieved when needed for logging in.
 
 ##### `IDPURL`
 

--- a/pkgs/api/jsonschema/samlsource.json
+++ b/pkgs/api/jsonschema/samlsource.json
@@ -44,8 +44,17 @@
     },
     "IDPMetadata": {
       "$friendlyName": "IDP Metadata",
-      "description": "Pass some XML data containing the IDP metadata that can be used for automatic configuration. If you pass this attribute, every other one will be overwritten with the data contained in the metadata file.",
+      "description": "Pass some XML data containing the IDP metadata that can be used for automatic configuration. If you pass this attribute, every other one will be overwritten with the data contained in the metadata file, but it does not take precendence over IDPMetadataURL.",
       "title": "IDPMetadata",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "IDPMetadataURL": {
+      "$friendlyName": "IDP Metadata URL",
+      "description": "The URL where to fetch the IDPMetadata. If this is set, all other IDP fields are ignored and the metadata will be retrieved when needed for logging in.",
+      "title": "IDPMetadataURL",
       "type": [
         "string",
         "null"

--- a/pkgs/api/openapi3/toplevel
+++ b/pkgs/api/openapi3/toplevel
@@ -1479,7 +1479,11 @@
             "type": "string"
           },
           "IDPMetadata": {
-            "description": "Pass some XML data containing the IDP metadata that can be used for automatic\nconfiguration. If you pass this attribute, every other one will be overwritten\nwith the data contained in the metadata file.",
+            "description": "Pass some XML data containing the IDP metadata that can be used for automatic\nconfiguration. If you pass this attribute, every other one will be overwritten\nwith the data contained in the metadata file, but it does not take precendence\nover IDPMetadataURL.",
+            "type": "string"
+          },
+          "IDPMetadataURL": {
+            "description": "The URL where to fetch the IDPMetadata. If this is set, all other IDP fields are\nignored and the metadata will be retrieved when needed for logging in.",
             "type": "string"
           },
           "IDPURL": {

--- a/pkgs/api/samlsource.go
+++ b/pkgs/api/samlsource.go
@@ -95,8 +95,13 @@ type SAMLSource struct {
 
 	// Pass some XML data containing the IDP metadata that can be used for automatic
 	// configuration. If you pass this attribute, every other one will be overwritten
-	// with the data contained in the metadata file.
+	// with the data contained in the metadata file, but it does not take precendence
+	// over IDPMetadataURL.
 	IDPMetadata string `json:"IDPMetadata,omitempty" msgpack:"IDPMetadata,omitempty" bson:"-" mapstructure:"IDPMetadata,omitempty"`
+
+	// The URL where to fetch the IDPMetadata. If this is set, all other IDP fields are
+	// ignored and the metadata will be retrieved when needed for logging in.
+	IDPMetadataURL string `json:"IDPMetadataURL,omitempty" msgpack:"IDPMetadataURL,omitempty" bson:"idpmetadataurl,omitempty" mapstructure:"IDPMetadataURL,omitempty"`
 
 	// URL of the identity provider.
 	IDPURL string `json:"IDPURL" msgpack:"IDPURL" bson:"idpurl" mapstructure:"IDPURL,omitempty"`
@@ -202,6 +207,7 @@ func (o *SAMLSource) GetBSON() (any, error) {
 	}
 	s.IDPCertificate = o.IDPCertificate
 	s.IDPIssuer = o.IDPIssuer
+	s.IDPMetadataURL = o.IDPMetadataURL
 	s.IDPURL = o.IDPURL
 	s.AudienceURI = o.AudienceURI
 	s.CreateTime = o.CreateTime
@@ -239,6 +245,7 @@ func (o *SAMLSource) SetBSON(raw bson.Raw) error {
 	o.ID = s.ID.Hex()
 	o.IDPCertificate = s.IDPCertificate
 	o.IDPIssuer = s.IDPIssuer
+	o.IDPMetadataURL = s.IDPMetadataURL
 	o.IDPURL = s.IDPURL
 	o.AudienceURI = s.AudienceURI
 	o.CreateTime = s.CreateTime
@@ -396,6 +403,7 @@ func (o *SAMLSource) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			IDPCertificate:             &o.IDPCertificate,
 			IDPIssuer:                  &o.IDPIssuer,
 			IDPMetadata:                &o.IDPMetadata,
+			IDPMetadataURL:             &o.IDPMetadataURL,
 			IDPURL:                     &o.IDPURL,
 			AudienceURI:                &o.AudienceURI,
 			CreateTime:                 &o.CreateTime,
@@ -427,6 +435,8 @@ func (o *SAMLSource) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			sp.IDPIssuer = &(o.IDPIssuer)
 		case "IDPMetadata":
 			sp.IDPMetadata = &(o.IDPMetadata)
+		case "IDPMetadataURL":
+			sp.IDPMetadataURL = &(o.IDPMetadataURL)
 		case "IDPURL":
 			sp.IDPURL = &(o.IDPURL)
 		case "audienceURI":
@@ -485,6 +495,9 @@ func (o *SAMLSource) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.IDPMetadata != nil {
 		o.IDPMetadata = *so.IDPMetadata
+	}
+	if so.IDPMetadataURL != nil {
+		o.IDPMetadataURL = *so.IDPMetadataURL
 	}
 	if so.IDPURL != nil {
 		o.IDPURL = *so.IDPURL
@@ -627,6 +640,8 @@ func (o *SAMLSource) ValueForAttribute(name string) any {
 		return o.IDPIssuer
 	case "IDPMetadata":
 		return o.IDPMetadata
+	case "IDPMetadataURL":
+		return o.IDPMetadataURL
 	case "IDPURL":
 		return o.IDPURL
 	case "audienceURI":
@@ -709,9 +724,21 @@ var SAMLSourceAttributesMap = map[string]elemental.AttributeSpecification{
 		ConvertedName:  "IDPMetadata",
 		Description: `Pass some XML data containing the IDP metadata that can be used for automatic
 configuration. If you pass this attribute, every other one will be overwritten
-with the data contained in the metadata file.`,
+with the data contained in the metadata file, but it does not take precendence
+over IDPMetadataURL.`,
 		Exposed: true,
 		Name:    "IDPMetadata",
+		Type:    "string",
+	},
+	"IDPMetadataURL": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "idpmetadataurl",
+		ConvertedName:  "IDPMetadataURL",
+		Description: `The URL where to fetch the IDPMetadata. If this is set, all other IDP fields are
+ignored and the metadata will be retrieved when needed for logging in.`,
+		Exposed: true,
+		Name:    "IDPMetadataURL",
+		Stored:  true,
 		Type:    "string",
 	},
 	"IDPURL": {
@@ -969,9 +996,21 @@ var SAMLSourceLowerCaseAttributesMap = map[string]elemental.AttributeSpecificati
 		ConvertedName:  "IDPMetadata",
 		Description: `Pass some XML data containing the IDP metadata that can be used for automatic
 configuration. If you pass this attribute, every other one will be overwritten
-with the data contained in the metadata file.`,
+with the data contained in the metadata file, but it does not take precendence
+over IDPMetadataURL.`,
 		Exposed: true,
 		Name:    "IDPMetadata",
+		Type:    "string",
+	},
+	"idpmetadataurl": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "idpmetadataurl",
+		ConvertedName:  "IDPMetadataURL",
+		Description: `The URL where to fetch the IDPMetadata. If this is set, all other IDP fields are
+ignored and the metadata will be retrieved when needed for logging in.`,
+		Exposed: true,
+		Name:    "IDPMetadataURL",
+		Stored:  true,
 		Type:    "string",
 	},
 	"idpurl": {
@@ -1260,8 +1299,13 @@ type SparseSAMLSource struct {
 
 	// Pass some XML data containing the IDP metadata that can be used for automatic
 	// configuration. If you pass this attribute, every other one will be overwritten
-	// with the data contained in the metadata file.
+	// with the data contained in the metadata file, but it does not take precendence
+	// over IDPMetadataURL.
 	IDPMetadata *string `json:"IDPMetadata,omitempty" msgpack:"IDPMetadata,omitempty" bson:"-" mapstructure:"IDPMetadata,omitempty"`
+
+	// The URL where to fetch the IDPMetadata. If this is set, all other IDP fields are
+	// ignored and the metadata will be retrieved when needed for logging in.
+	IDPMetadataURL *string `json:"IDPMetadataURL,omitempty" msgpack:"IDPMetadataURL,omitempty" bson:"idpmetadataurl,omitempty" mapstructure:"IDPMetadataURL,omitempty"`
 
 	// URL of the identity provider.
 	IDPURL *string `json:"IDPURL,omitempty" msgpack:"IDPURL,omitempty" bson:"idpurl,omitempty" mapstructure:"IDPURL,omitempty"`
@@ -1372,6 +1416,9 @@ func (o *SparseSAMLSource) GetBSON() (any, error) {
 	if o.IDPIssuer != nil {
 		s.IDPIssuer = o.IDPIssuer
 	}
+	if o.IDPMetadataURL != nil {
+		s.IDPMetadataURL = o.IDPMetadataURL
+	}
 	if o.IDPURL != nil {
 		s.IDPURL = o.IDPURL
 	}
@@ -1447,6 +1494,9 @@ func (o *SparseSAMLSource) SetBSON(raw bson.Raw) error {
 	}
 	if s.IDPIssuer != nil {
 		o.IDPIssuer = s.IDPIssuer
+	}
+	if s.IDPMetadataURL != nil {
+		o.IDPMetadataURL = s.IDPMetadataURL
 	}
 	if s.IDPURL != nil {
 		o.IDPURL = s.IDPURL
@@ -1524,6 +1574,9 @@ func (o *SparseSAMLSource) ToPlain() elemental.PlainIdentifiable {
 	}
 	if o.IDPMetadata != nil {
 		out.IDPMetadata = *o.IDPMetadata
+	}
+	if o.IDPMetadataURL != nil {
+		out.IDPMetadataURL = *o.IDPMetadataURL
 	}
 	if o.IDPURL != nil {
 		out.IDPURL = *o.IDPURL
@@ -1736,6 +1789,7 @@ type mongoAttributesSAMLSource struct {
 	ID                         bson.ObjectId     `bson:"_id,omitempty"`
 	IDPCertificate             string            `bson:"idpcertificate"`
 	IDPIssuer                  string            `bson:"idpissuer"`
+	IDPMetadataURL             string            `bson:"idpmetadataurl,omitempty"`
 	IDPURL                     string            `bson:"idpurl"`
 	AudienceURI                string            `bson:"audienceuri"`
 	CreateTime                 time.Time         `bson:"createtime"`
@@ -1758,6 +1812,7 @@ type mongoAttributesSparseSAMLSource struct {
 	ID                         bson.ObjectId     `bson:"_id,omitempty"`
 	IDPCertificate             *string           `bson:"idpcertificate,omitempty"`
 	IDPIssuer                  *string           `bson:"idpissuer,omitempty"`
+	IDPMetadataURL             *string           `bson:"idpmetadataurl,omitempty"`
 	IDPURL                     *string           `bson:"idpurl,omitempty"`
 	AudienceURI                *string           `bson:"audienceuri,omitempty"`
 	CreateTime                 *time.Time        `bson:"createtime,omitempty"`

--- a/pkgs/api/specs/samlsource.spec
+++ b/pkgs/api/specs/samlsource.spec
@@ -55,9 +55,20 @@ attributes:
     description: |-
       Pass some XML data containing the IDP metadata that can be used for automatic
       configuration. If you pass this attribute, every other one will be overwritten
-      with the data contained in the metadata file.
+      with the data contained in the metadata file, but it does not take precendence
+      over IDPMetadataURL.
     type: string
     exposed: true
+    omit_empty: true
+
+  - name: IDPMetadataURL
+    friendly_name: IDP Metadata URL
+    description: |-
+      The URL where to fetch the IDPMetadata. If this is set, all other IDP fields are
+      ignored and the metadata will be retrieved when needed for logging in.
+    type: string
+    exposed: true
+    stored: true
     omit_empty: true
 
   - name: IDPURL


### PR DESCRIPTION
This patch adds the property IDPMetadataURL which allows to give a URL pointing to a IDP Metadata XML file instead of prodividing it directly in IDPMetadata.

When the IDPMetadataURL is set, the metadata file will be retrieved and cached when needed to authn a user. The data is cached for 1h.

This allows us to support Microsoft Identity Platform.