### PR TITLE
new: add --jwt-previous-cert

### DIFF
--- a/internal/processors/issue.go
+++ b/internal/processors/issue.go
@@ -251,10 +251,10 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 	}
 	idt.Source = originalSource
 
-	k := p.jwks.GetLast()
+	k := p.jwks.GetLastWithPrivate()
 	tkn, err := idt.JWT(k.PrivateKey(), k.KID, p.issuer, audience, exp, req.Cloak)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to sign jwt: %w", err)
 	}
 
 	req.Validity = time.Until(idt.ExpiresAt.Time).Round(time.Second).String()

--- a/pkgs/token/jwks.go
+++ b/pkgs/token/jwks.go
@@ -200,6 +200,25 @@ func (j *JWKS) GetLast() *JWKSKey {
 	return j.Keys[len(j.Keys)-1]
 }
 
+// GetLastWithPrivate returns the last inserted key that contains a private key.
+func (j *JWKS) GetLastWithPrivate() *JWKSKey {
+
+	j.RLock()
+	defer j.RUnlock()
+
+	if len(j.Keys) == 0 {
+		return nil
+	}
+
+	for i := len(j.Keys) - 1; i >= 0; i-- {
+		if k := j.Keys[i]; k.private != nil {
+			return k
+		}
+	}
+
+	return nil
+}
+
 // Del deletes the key with the given ID.
 // Returns true if something was deleted, false
 // otherwise.

--- a/pkgs/token/jwks_test.go
+++ b/pkgs/token/jwks_test.go
@@ -41,6 +41,7 @@ func TestJWKSCrud(t *testing.T) {
 			So(len(k.keyMap), ShouldEqual, 1)
 			So(len(k.Keys), ShouldEqual, 1)
 			So(k.GetLast(), ShouldNotBeNil)
+			So(k.GetLastWithPrivate(), ShouldNotBeNil)
 
 			Convey("Appending it again should fail", func() {
 				err := k.Append(cert1)


### PR DESCRIPTION
This allows to path one of more certificates that are still considered valid until expiration, in order to replace the main one with a newer version to perform key rotation