### PR TITLE
permissions: fix bad computation

### DIFF
--- a/pkgs/permissions/retriever.go
+++ b/pkgs/permissions/retriever.go
@@ -154,7 +154,11 @@ func (a *retriever) Permissions(ctx context.Context, claims []string, ns string,
 				out[identity] = perms
 			} else {
 				for verb := range perms {
-					out[identity][verb] = true
+					if _, ok := out[identity][verb]; ok {
+						out[identity][verb] = out[identity][verb] && perms[verb]
+					} else {
+						out[identity][verb] = perms[verb]
+					}
 				}
 			}
 		}


### PR DESCRIPTION
During permissions aggregation, the boolean value must be ANDed with the previous value if any