### PR TITLE
import: honor order and entries of import data when creating

### DIFF
--- a/pkgs/importing/import.go
+++ b/pkgs/importing/import.go
@@ -147,8 +147,18 @@ func Import(
 		}
 	}
 
+	if len(hashed) == 0 {
+		return nil
+	}
+
 	// Finally, we create the remaining objects.
-	for _, o := range hashed {
+	for _, obj := range lst {
+
+		o := obj.(Importable)
+
+		if _, ok := hashed[o.GetImportHash()]; !ok {
+			continue
+		}
 
 		ns := namespace
 		if localns := o.GetNamespace(); localns != "" {


### PR DESCRIPTION
#### Description
There were two problems with the import that caused sporadic issues with data that requires order:

1) Order is not kept on creation due to using a map.
2) Hashes sometimes overlap with similar data after sanitization. This leads to the import missing data on creation as we map hash -> obj. If hash is a duplicate, old item is overwritten in the map.

Instead, we will now use the original list and use the hash map to verify the item should be created.