### PR TITLE
spec: prevent setting trailling and leading spaces in keys

### DIFF
--- a/pkgs/api/custom_validations.go
+++ b/pkgs/api/custom_validations.go
@@ -242,6 +242,19 @@ func ValidateSAMLSource(source *SAMLSource) error {
 	return nil
 }
 
+// ValidateKeys validate the given included keys.
+func ValidateKeys(attribute string, keys []string) error {
+
+	for _, k := range keys {
+		kk := strings.TrimSpace(k)
+		if kk != k {
+			return makeErr(attribute, fmt.Sprintf("key '%s' must not contains any leading or trailing spaces", k))
+		}
+	}
+
+	return nil
+}
+
 func makeErr(attribute string, message string) elemental.Error {
 
 	err := elemental.NewError(

--- a/pkgs/api/custom_validations_test.go
+++ b/pkgs/api/custom_validations_test.go
@@ -1244,3 +1244,111 @@ func TestValidateSAMLSource(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateKeys(t *testing.T) {
+	type args struct {
+		attribute string
+		keys      []string
+	}
+	tests := []struct {
+		name string
+		args func(t *testing.T) args
+
+		wantErr    bool
+		inspectErr func(err error, t *testing.T) //use for more precise error evaluation after test
+	}{
+		{
+			"ok",
+			func(*testing.T) args {
+				return args{
+					attribute: "attr",
+					keys:      []string{"a", "b"},
+				}
+			},
+			false,
+			nil,
+		},
+		{
+			"empty",
+			func(*testing.T) args {
+				return args{
+					attribute: "attr",
+					keys:      []string{},
+				}
+			},
+			false,
+			nil,
+		},
+		{
+			"nil",
+			func(*testing.T) args {
+				return args{
+					attribute: "attr",
+					keys:      nil,
+				}
+			},
+			false,
+			nil,
+		},
+		{
+			"leading",
+			func(*testing.T) args {
+				return args{
+					attribute: "attr",
+					keys:      []string{"ok", " ba"},
+				}
+			},
+			true,
+			nil,
+		},
+		{
+			"trailing",
+			func(*testing.T) args {
+				return args{
+					attribute: "attr",
+					keys:      []string{"ok", "ba "},
+				}
+			},
+			true,
+			nil,
+		},
+		{
+			"leading & trailing",
+			func(*testing.T) args {
+				return args{
+					attribute: "attr",
+					keys:      []string{"ok", " ba "},
+				}
+			},
+			true,
+			nil,
+		},
+		{
+			"middle",
+			func(*testing.T) args {
+				return args{
+					attribute: "attr",
+					keys:      []string{"ok", "b a"},
+				}
+			},
+			false,
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tArgs := tt.args(t)
+
+			err := ValidateKeys(tArgs.attribute, tArgs.keys)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateKeys error = %v, wantErr: %t", err, tt.wantErr)
+			}
+
+			if tt.inspectErr != nil {
+				tt.inspectErr(err, t)
+			}
+		})
+	}
+}

--- a/pkgs/api/ldapsource.go
+++ b/pkgs/api/ldapsource.go
@@ -607,6 +607,14 @@ func (o *LDAPSource) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
+	if err := ValidateKeys("ignoredKeys", o.IgnoredKeys); err != nil {
+		errors = errors.Append(err)
+	}
+
+	if err := ValidateKeys("includedKeys", o.IncludedKeys); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if o.Modifier != nil {
 		elemental.ResetDefaultForZeroValues(o.Modifier)
 		if err := o.Modifier.Validate(); err != nil {

--- a/pkgs/api/samlsource.go
+++ b/pkgs/api/samlsource.go
@@ -582,6 +582,14 @@ func (o *SAMLSource) Validate() error {
 	errors := elemental.Errors{}
 	requiredErrors := elemental.Errors{}
 
+	if err := ValidateKeys("ignoredKeys", o.IgnoredKeys); err != nil {
+		errors = errors.Append(err)
+	}
+
+	if err := ValidateKeys("includedKeys", o.IncludedKeys); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if o.Modifier != nil {
 		elemental.ResetDefaultForZeroValues(o.Modifier)
 		if err := o.Modifier.Validate(); err != nil {

--- a/pkgs/api/specs/_validation.mapping
+++ b/pkgs/api/specs/_validation.mapping
@@ -18,6 +18,10 @@ $issue:
   elemental:
     name: ValidateIssue
 
+$keyValidation:
+  elemental:
+    name: ValidateKeys
+
 $pem:
   elemental:
     name: ValidatePEM

--- a/pkgs/api/specs/ldapsource.spec
+++ b/pkgs/api/specs/ldapsource.spec
@@ -117,6 +117,8 @@ attributes:
     subtype: string
     stored: true
     omit_empty: true
+    validations:
+    - $keyValidation
 
   - name: includedKeys
     friendly_name: IncludedKeys
@@ -128,6 +130,8 @@ attributes:
     subtype: string
     stored: true
     omit_empty: true
+    validations:
+    - $keyValidation
 
   - name: modifier
     friendly_name: Modifier

--- a/pkgs/api/specs/samlsource.spec
+++ b/pkgs/api/specs/samlsource.spec
@@ -105,6 +105,8 @@ attributes:
     exposed: true
     subtype: string
     stored: true
+    validations:
+    - $keyValidation
 
   - name: includedKeys
     friendly_name: IncludedKeys
@@ -115,6 +117,8 @@ attributes:
     exposed: true
     subtype: string
     stored: true
+    validations:
+    - $keyValidation
 
   - name: modifier
     friendly_name: Modifier


### PR DESCRIPTION
for ignore/included keys in SAML/LDAP