### PR TITLE
new: allows to set extensions in the cert to match source

### DIFF
--- a/cmd/a3s/main.go
+++ b/cmd/a3s/main.go
@@ -486,6 +486,16 @@ func main() {
 		slog.Info("Forbidden opaque keys", "keys", cfg.JWT.JWTForbiddenOpaqueKeys)
 	}
 
+	oidSourceName, oidSourceNamespace, err := cfg.SourceOIDs()
+	if err != nil {
+		slog.Error("Unable to parse source OIDs", err)
+		os.Exit(1)
+	}
+
+	if len(oidSourceName) > 0 || len(oidSourceNamespace) > 0 {
+		slog.Info("OID source set", "name", oidSourceName, "namespace", oidSourceNamespace)
+	}
+
 	bahamut.RegisterProcessorOrDie(server,
 		processors.NewIssueProcessor(
 			m,
@@ -503,6 +513,8 @@ func main() {
 			cfg.MTLSHeaderConf.Passphrase,
 			pluginModifier,
 			binaryModifier,
+			oidSourceName,
+			oidSourceNamespace,
 		),
 		api.IssueIdentity,
 	)


### PR DESCRIPTION
it is now possible to set --oid-source-name and --oid-source-namespace. When they are set, the issue processor will look for extensions with these OID to deduct the source name and namespace for a MTLS authentication. This way, no further parameters other than the client cert need to be sent.