### PR TITLE
new: revocation by subject

### DIFF
--- a/internal/processors/groups.go
+++ b/internal/processors/groups.go
@@ -30,7 +30,7 @@ func NewGroupProcessor(
 // ProcessCreate handles the creates requests for Groups.
 func (p *GroupsProcessors) ProcessCreate(bctx bahamut.Context) error {
 	return crud.Create(bctx, p.manipulator, bctx.InputData().(*api.Group),
-		crud.OptionPreWriteHook(p.makePreHook(bctx)),
+		crud.OptionPreWriteHook(p.makePreHook()),
 		crud.OptionPostWriteHook(p.makeNotify()),
 	)
 }
@@ -48,7 +48,7 @@ func (p *GroupsProcessors) ProcessRetrieve(bctx bahamut.Context) error {
 // ProcessUpdate handles the update requests for Groups.
 func (p *GroupsProcessors) ProcessUpdate(bctx bahamut.Context) error {
 	return crud.Update(bctx, p.manipulator, bctx.InputData().(*api.Group),
-		crud.OptionPreWriteHook(p.makePreHook(bctx)),
+		crud.OptionPreWriteHook(p.makePreHook()),
 		crud.OptionPostWriteHook(p.makeNotify()),
 	)
 }
@@ -77,7 +77,7 @@ func (p *GroupsProcessors) makeNotify() crud.PostWriteHook {
 	}
 }
 
-func (p *GroupsProcessors) makePreHook(_ bahamut.Context) crud.PreWriteHook {
+func (p *GroupsProcessors) makePreHook() crud.PreWriteHook {
 	return func(obj elemental.Identifiable, original elemental.Identifiable) error {
 		group := obj.(*api.Group)
 		group.FlattenedSubject = flattenTags(group.Subject)

--- a/pkgs/api/doc/documentation.md
+++ b/pkgs/api/doc/documentation.md
@@ -2515,7 +2515,13 @@ Type: `string`
 
 The namespace of the object.
 
-##### `tokenID` [`required`]
+##### `subject`
+
+Type: `[][]string`
+
+A tag expression that identifies the authorized user(s).
+
+##### `tokenID`
 
 Type: `string`
 

--- a/pkgs/api/identities_registry.go
+++ b/pkgs/api/identities_registry.go
@@ -140,8 +140,10 @@ var (
 		"permissions": nil,
 		"revocation": {
 			{":shard", ":unique", "zone", "zHash"},
+			{"flattenedSubject"},
 			{"namespace"},
 			{"namespace", "ID"},
+			{"namespace", "flattenedSubject"},
 			{"namespace", "tokenid"},
 			{"tokenid"},
 		},

--- a/pkgs/api/jsonschema/revocation.json
+++ b/pkgs/api/jsonschema/revocation.json
@@ -52,12 +52,26 @@
         "null"
       ]
     },
+    "subject": {
+      "$friendlyName": "Subject",
+      "description": "A tag expression that identifies the authorized user(s).",
+      "items": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "title": "subject",
+      "type": "array"
+    },
     "tokenID": {
       "$friendlyName": "TokenID",
-      "$required": true,
       "description": "The ID of the revoked token.",
       "title": "tokenID",
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "updateTime": {
       "$friendlyName": "UpdateTime",
@@ -70,9 +84,7 @@
       ]
     }
   },
-  "required": [
-    "tokenID"
-  ],
+  "required": [],
   "title": "Revocation",
   "type": "object"
 }

--- a/pkgs/api/openapi3/toplevel
+++ b/pkgs/api/openapi3/toplevel
@@ -1520,6 +1520,16 @@
             "readOnly": true,
             "type": "string"
           },
+          "subject": {
+            "description": "A tag expression that identifies the authorized user(s).",
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
           "tokenID": {
             "description": "The ID of the revoked token.",
             "example": "ff199ae8-8e15-4daf-9c90-155d9cba90c2",
@@ -1532,9 +1542,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "tokenID"
-        ],
         "type": "object"
       },
       "samlsource": {

--- a/pkgs/api/specs/revocation.spec
+++ b/pkgs/api/specs/revocation.spec
@@ -21,6 +21,9 @@ indexes:
 - - namespace
   - tokenid
 - - tokenid
+- - namespace
+  - flattenedSubject
+- - flattenedSubject
 
 # Attributes
 attributes:
@@ -33,6 +36,13 @@ attributes:
     stored: true
     example_value: "2023-11-08T18:38:04.51Z"
 
+  - name: flattenedSubject
+    friendly_name: FlattenedSubject
+    description: This is a set of all subject tags for matching in the DB.
+    type: list
+    subtype: string
+    stored: true
+
   - name: propagate
     friendly_name: Propagate
     description: Propagates the api authorization to all of its children. This is
@@ -43,11 +53,22 @@ attributes:
     getter: true
     setter: true
 
+  - name: subject
+    friendly_name: Subject
+    description: A tag expression that identifies the authorized user(s).
+    type: external
+    exposed: true
+    subtype: '[][]string'
+    stored: true
+    orderable: true
+    validations:
+    - $tags_expression
+    - $authorization_subject
+
   - name: tokenID
     friendly_name: TokenID
     description: The ID of the revoked token.
     type: string
     exposed: true
     stored: true
-    required: true
     example_value: ff199ae8-8e15-4daf-9c90-155d9cba90c2

--- a/pkgs/authorizer/authorizer.go
+++ b/pkgs/authorizer/authorizer.go
@@ -201,7 +201,7 @@ func (a *authorizer) CheckAuthorization(ctx context.Context, claims []string, op
 
 	// Handle token revocation
 	if r := a.revocationCache.Get(ns, key); r == nil || r.Expired() {
-		revoked, err := a.retriever.Revoked(ctx, ns, cfg.tokenID)
+		revoked, err := a.retriever.Revoked(ctx, ns, cfg.tokenID, claims)
 		if err != nil {
 			return false, err
 		}

--- a/pkgs/authorizer/authorizer_test.go
+++ b/pkgs/authorizer/authorizer_test.go
@@ -262,7 +262,7 @@ func TestCheckPermissions(t *testing.T) {
 
 		Convey("Calling with a revoked token should fail", func() {
 
-			r.MockRevoked(t, func(context.Context, string, string) (bool, error) {
+			r.MockRevoked(t, func(context.Context, string, string, []string) (bool, error) {
 				return true, nil
 			})
 
@@ -274,7 +274,7 @@ func TestCheckPermissions(t *testing.T) {
 
 			Convey("Calling one more time should use the cache and work", func() {
 
-				r.MockRevoked(t, func(context.Context, string, string) (bool, error) {
+				r.MockRevoked(t, func(context.Context, string, string, []string) (bool, error) {
 					return false, nil // this simulates a changes that was not pushed, so cache will be used.
 				})
 

--- a/pkgs/permissions/retriever_mock.go
+++ b/pkgs/permissions/retriever_mock.go
@@ -8,14 +8,14 @@ import (
 
 type mockedMethods struct {
 	permissionsMock func(context.Context, []string, string, ...RetrieverOption) (PermissionMap, error)
-	revokedMock     func(context.Context, string, string) (bool, error)
+	revokedMock     func(context.Context, string, string, []string) (bool, error)
 }
 
 // A MockRetriever allows to mock a permissions.Retriever for unit tests.
 type MockRetriever interface {
 	Retriever
 	MockPermissions(t *testing.T, impl func(context.Context, []string, string, ...RetrieverOption) (PermissionMap, error))
-	MockRevoked(t *testing.T, impl func(context.Context, string, string) (bool, error))
+	MockRevoked(t *testing.T, impl func(context.Context, string, string, []string) (bool, error))
 }
 
 type mockRetriever struct {
@@ -42,7 +42,7 @@ func (r *mockRetriever) MockPermissions(t *testing.T, impl func(context.Context,
 }
 
 // MockRevoked replaces the Revoked implementation with the given function.
-func (r *mockRetriever) MockRevoked(t *testing.T, impl func(context.Context, string, string) (bool, error)) {
+func (r *mockRetriever) MockRevoked(t *testing.T, impl func(context.Context, string, string, []string) (bool, error)) {
 
 	r.Lock()
 	defer r.Unlock()
@@ -62,13 +62,13 @@ func (r *mockRetriever) Permissions(ctx context.Context, claims []string, ns str
 	return PermissionMap{}, nil
 }
 
-func (r *mockRetriever) Revoked(ctx context.Context, namespace string, tokenID string) (bool, error) {
+func (r *mockRetriever) Revoked(ctx context.Context, namespace string, tokenID string, claims []string) (bool, error) {
 
 	r.Lock()
 	defer r.Unlock()
 
 	if mock := r.currentMocks(r.currentTest); mock != nil && mock.revokedMock != nil {
-		return mock.revokedMock(ctx, namespace, tokenID)
+		return mock.revokedMock(ctx, namespace, tokenID, claims)
 	}
 
 	return false, nil

--- a/pkgs/permissions/retriever_mock_test.go
+++ b/pkgs/permissions/retriever_mock_test.go
@@ -31,16 +31,16 @@ func TestMockRetriever(t *testing.T) {
 		})
 
 		Convey("Calling Revoked without mock should work", func() {
-			revoked, err := r.Revoked(context.Background(), "/", "abcdef")
+			revoked, err := r.Revoked(context.Background(), "/", "abcdef", []string{"a"})
 			So(err, ShouldBeNil)
 			So(revoked, ShouldBeFalse)
 		})
 
 		Convey("Calling Revoked with mock should work", func() {
-			r.MockRevoked(t, func(context.Context, string, string) (bool, error) {
+			r.MockRevoked(t, func(context.Context, string, string, []string) (bool, error) {
 				return true, nil
 			})
-			revoked, err := r.Revoked(context.Background(), "/", "abcdef")
+			revoked, err := r.Revoked(context.Background(), "/", "abcdef", []string{"a"})
 			So(err, ShouldBeNil)
 			So(revoked, ShouldBeTrue)
 		})

--- a/pkgs/permissions/revocation.go
+++ b/pkgs/permissions/revocation.go
@@ -1,0 +1,57 @@
+package permissions
+
+import (
+	"context"
+	"fmt"
+
+	"go.acuvity.ai/a3s/pkgs/api"
+	"go.acuvity.ai/elemental"
+	"go.acuvity.ai/manipulate"
+)
+
+func checkRevocation(ctx context.Context, m manipulate.Manipulator, namespace string, tokenID string, claims []string) (bool, error) {
+
+	var itags = make([]any, len(claims))
+	for i, c := range claims {
+		itags[i] = c
+	}
+
+	revs := api.SparseRevocationsList{}
+
+	if err := m.RetrieveMany(
+		manipulate.NewContext(
+			ctx,
+			manipulate.ContextOptionNamespace(namespace),
+			manipulate.ContextOptionPropagated(true),
+			manipulate.ContextOptionFields([]string{"tokenID", "subject"}),
+			manipulate.ContextOptionFilter(
+				elemental.NewFilterComposer().Or(
+					elemental.NewFilterComposer().
+						WithKey("tokenID").Equals(tokenID).
+						Done(),
+					elemental.NewFilterComposer().
+						WithKey("flattenedsubject").In(itags...).
+						Done(),
+				).Done(),
+			),
+		),
+		&revs,
+	); err != nil {
+		return false, fmt.Errorf("unable to retrieve revocations: %w", err)
+	}
+
+	for _, rev := range revs {
+		if rev.TokenID != nil && *rev.TokenID == tokenID {
+			return true, nil
+		}
+
+		if rev.Subject != nil {
+			if Match(*rev.Subject, claims) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+
+}


### PR DESCRIPTION
Revocation were only used to revoke a single token by its JID. This patch makes them more powerful by allowing to set a subject instead. During a revocation check, if the user claims match any active revocation subject, then the token will be considered as revoked.

Just setting the tokenID still work. If both tokenID and subject are set in the same revocation, any matching condition will consider the token revoked.