### PR TITLE
issue: instead of assuming a 401 use returned elemental.Error

### DIFF
--- a/internal/issuer/mtlsissuer/utils.go
+++ b/internal/issuer/mtlsissuer/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"go.acuvity.ai/a3s/pkgs/api"
+	"go.acuvity.ai/elemental"
 )
 
 func getPrincipalName(iss *mtlsIssuer, cert *x509.Certificate) (string, error) {
@@ -23,5 +24,11 @@ func getPrincipalName(iss *mtlsIssuer, cert *x509.Certificate) (string, error) {
 
 	default:
 		panic("invalid mtls source principal user field")
+	}
+}
+
+func makeErrMaker(provider string) func(title string, desc string, code int) error {
+	return func(title string, desc string, code int) error {
+		return elemental.NewError(title, desc, "a3s:mtlssource:"+provider, code)
 	}
 }

--- a/internal/processors/issue.go
+++ b/internal/processors/issue.go
@@ -277,6 +277,10 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 	}
 
 	if err != nil {
+		eerr := elemental.Error{}
+		if errors.As(err, &eerr) {
+			return eerr
+		}
 		return elemental.NewError("Unauthorized", err.Error(), "a3s:authn", http.StatusUnauthorized)
 	}
 


### PR DESCRIPTION
If the issuers return an elemental.Error, simply forward it. Only assume 401 for simple error.