### PR TITLE
a3s: support for checking self permissions

### DIFF
--- a/internal/processors/permissions.go
+++ b/internal/processors/permissions.go
@@ -23,6 +23,14 @@ func (p *PermissionsProcessor) ProcessCreate(bctx bahamut.Context) error {
 
 	req := bctx.InputData().(*api.Permissions)
 
+	if len(req.Claims) == 0 {
+		req.Claims = bctx.Claims()
+	}
+
+	if req.Namespace == "" {
+		req.Namespace = bctx.Request().Namespace
+	}
+
 	restrictions := permissions.Restrictions{
 		Namespace:   req.RestrictedNamespace,
 		Networks:    req.RestrictedNetworks,

--- a/pkgs/api/doc/documentation.md
+++ b/pkgs/api/doc/documentation.md
@@ -2388,11 +2388,11 @@ Type: `string`
 
 IP of the client.
 
-##### `claims` [`required`]
+##### `claims`
 
 Type: `[]string`
 
-The list of claims.
+The list of claims. If empty the claims of the current token will be used.
 
 ##### `collectAccessibleNamespaces`
 
@@ -2429,11 +2429,12 @@ Type: `string`
 
 Return an eventual error.
 
-##### `namespace` [`required`]
+##### `namespace`
 
 Type: `string`
 
-The namespace where to check permission from.
+The namespace where to check permission from. If not set, X-Namespace header
+will be used.
 
 ##### `offloadPermissionsRestrictions`
 

--- a/pkgs/api/jsonschema/permissions.json
+++ b/pkgs/api/jsonschema/permissions.json
@@ -29,10 +29,12 @@
     },
     "claims": {
       "$friendlyName": "Claims",
-      "$required": true,
-      "description": "The list of claims.",
+      "description": "The list of claims. If empty the claims of the current token will be used.",
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "title": "claims",
       "type": "array"
@@ -93,10 +95,12 @@
     },
     "namespace": {
       "$friendlyName": "Namespace",
-      "$required": true,
-      "description": "The namespace where to check permission from.",
+      "description": "The namespace where to check permission from. If not set, X-Namespace header will be used.",
       "title": "namespace",
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "offloadPermissionsRestrictions": {
       "$friendlyName": "OffloadPermissionsRestrictions",
@@ -163,10 +167,7 @@
       ]
     }
   },
-  "required": [
-    "claims",
-    "namespace"
-  ],
+  "required": [],
   "title": "Permissions",
   "type": "object"
 }

--- a/pkgs/api/openapi3/toplevel
+++ b/pkgs/api/openapi3/toplevel
@@ -1501,7 +1501,7 @@
             "type": "string"
           },
           "claims": {
-            "description": "The list of claims.",
+            "description": "The list of claims. If empty the claims of the current token will be used.",
             "example": [
               "sourcetype=mtls",
               "sourcename=my-source",
@@ -1544,7 +1544,7 @@
             "type": "string"
           },
           "namespace": {
-            "description": "The namespace where to check permission from.",
+            "description": "The namespace where to check permission from. If not set, X-Namespace header\nwill be used.",
             "example": "/acme",
             "type": "string"
           },
@@ -1593,10 +1593,6 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "claims",
-          "namespace"
-        ],
         "type": "object"
       },
       "revocation": {

--- a/pkgs/api/permissions.go
+++ b/pkgs/api/permissions.go
@@ -90,7 +90,7 @@ type Permissions struct {
 	// IP of the client.
 	IP string `json:"IP" msgpack:"IP" bson:"-" mapstructure:"IP,omitempty"`
 
-	// The list of claims.
+	// The list of claims. If empty the claims of the current token will be used.
 	Claims []string `json:"claims" msgpack:"claims" bson:"-" mapstructure:"claims,omitempty"`
 
 	// If true, the property collectedAccssibleNamespaces will be filled with the list
@@ -113,7 +113,8 @@ type Permissions struct {
 	// Return an eventual error.
 	Error string `json:"error,omitempty" msgpack:"error,omitempty" bson:"-" mapstructure:"error,omitempty"`
 
-	// The namespace where to check permission from.
+	// The namespace where to check permission from. If not set, X-Namespace header
+	// will be used.
 	Namespace string `json:"namespace" msgpack:"namespace" bson:"-" mapstructure:"namespace,omitempty"`
 
 	// If true, skips computing restriction intersections.
@@ -388,14 +389,6 @@ func (o *Permissions) Validate() error {
 	errors := elemental.Errors{}
 	requiredErrors := elemental.Errors{}
 
-	if err := elemental.ValidateRequiredExternal("claims", o.Claims); err != nil {
-		requiredErrors = requiredErrors.Append(err)
-	}
-
-	if err := elemental.ValidateRequiredString("namespace", o.Namespace); err != nil {
-		requiredErrors = requiredErrors.Append(err)
-	}
-
 	if len(requiredErrors) > 0 {
 		return requiredErrors
 	}
@@ -486,10 +479,9 @@ var PermissionsAttributesMap = map[string]elemental.AttributeSpecification{
 	"Claims": {
 		AllowedChoices: []string{},
 		ConvertedName:  "Claims",
-		Description:    `The list of claims.`,
+		Description:    `The list of claims. If empty the claims of the current token will be used.`,
 		Exposed:        true,
 		Name:           "claims",
-		Required:       true,
 		SubType:        "string",
 		Type:           "list",
 	},
@@ -547,11 +539,11 @@ groups used to resolve the permissions.`,
 	"Namespace": {
 		AllowedChoices: []string{},
 		ConvertedName:  "Namespace",
-		Description:    `The namespace where to check permission from.`,
-		Exposed:        true,
-		Name:           "namespace",
-		Required:       true,
-		Type:           "string",
+		Description: `The namespace where to check permission from. If not set, X-Namespace header
+will be used.`,
+		Exposed: true,
+		Name:    "namespace",
+		Type:    "string",
 	},
 	"OffloadPermissionsRestrictions": {
 		AllowedChoices: []string{},
@@ -629,10 +621,9 @@ var PermissionsLowerCaseAttributesMap = map[string]elemental.AttributeSpecificat
 	"claims": {
 		AllowedChoices: []string{},
 		ConvertedName:  "Claims",
-		Description:    `The list of claims.`,
+		Description:    `The list of claims. If empty the claims of the current token will be used.`,
 		Exposed:        true,
 		Name:           "claims",
-		Required:       true,
 		SubType:        "string",
 		Type:           "list",
 	},
@@ -690,11 +681,11 @@ groups used to resolve the permissions.`,
 	"namespace": {
 		AllowedChoices: []string{},
 		ConvertedName:  "Namespace",
-		Description:    `The namespace where to check permission from.`,
-		Exposed:        true,
-		Name:           "namespace",
-		Required:       true,
-		Type:           "string",
+		Description: `The namespace where to check permission from. If not set, X-Namespace header
+will be used.`,
+		Exposed: true,
+		Name:    "namespace",
+		Type:    "string",
 	},
 	"offloadpermissionsrestrictions": {
 		AllowedChoices: []string{},
@@ -820,7 +811,7 @@ type SparsePermissions struct {
 	// IP of the client.
 	IP *string `json:"IP,omitempty" msgpack:"IP,omitempty" bson:"-" mapstructure:"IP,omitempty"`
 
-	// The list of claims.
+	// The list of claims. If empty the claims of the current token will be used.
 	Claims *[]string `json:"claims,omitempty" msgpack:"claims,omitempty" bson:"-" mapstructure:"claims,omitempty"`
 
 	// If true, the property collectedAccssibleNamespaces will be filled with the list
@@ -843,7 +834,8 @@ type SparsePermissions struct {
 	// Return an eventual error.
 	Error *string `json:"error,omitempty" msgpack:"error,omitempty" bson:"-" mapstructure:"error,omitempty"`
 
-	// The namespace where to check permission from.
+	// The namespace where to check permission from. If not set, X-Namespace header
+	// will be used.
 	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"-" mapstructure:"namespace,omitempty"`
 
 	// If true, skips computing restriction intersections.

--- a/pkgs/api/specs/permissions.spec
+++ b/pkgs/api/specs/permissions.spec
@@ -25,11 +25,11 @@ attributes:
 
   - name: claims
     friendly_name: Claims
-    description: The list of claims.
+    description: The list of claims. If empty the claims of the current token will
+      be used.
     type: list
     exposed: true
     subtype: string
-    required: true
     example_value:
     - sourcetype=mtls
     - sourcename=my-source
@@ -85,10 +85,11 @@ attributes:
 
   - name: namespace
     friendly_name: Namespace
-    description: The namespace where to check permission from.
+    description: |-
+      The namespace where to check permission from. If not set, X-Namespace header
+      will be used.
     type: string
     exposed: true
-    required: true
     example_value: /acme
 
   - name: offloadPermissionsRestrictions

--- a/pkgs/authenticator/authenticator.go
+++ b/pkgs/authenticator/authenticator.go
@@ -72,19 +72,34 @@ func (a *Authenticator) AuthenticateSession(session bahamut.Session) (bahamut.Au
 // AuthenticateRequest authenticates the request from the given bahamut.Context.
 func (a *Authenticator) AuthenticateRequest(bctx bahamut.Context) (bahamut.AuthAction, error) {
 
+	// Convoluted order of things here: we get the token and
+	// try to validate if present, but we don't do anything.
+	// Then we check if the resource is public. If so, we say ok
+	// irrespective of any error parsing the token.
+	// Otherwise, we check for an actual error and the actual
+	// decision.
+	// This allows to set the bctx.Claims, even if the resource is
+	// public.
+
+	token := token.FromRequest(bctx.Request())
+	action, idt, err := a.CheckAuthentication(bctx.Context(), token)
+
+	if idt != nil {
+		bctx.SetClaims(idt.Identity)
+	}
+
+	// If the resource is public, action is OK, and if there was
+	// a valid token, claims have been set.
 	if _, ok := a.ignoredResources[bctx.Request().Identity.Category]; ok {
 		return bahamut.AuthActionOK, nil
 	}
 
-	token := token.FromRequest(bctx.Request())
-
-	action, idt, err := a.CheckAuthentication(bctx.Context(), token)
+	// If not public and we could not parse the token, it's KO
 	if err != nil {
 		return bahamut.AuthActionKO, err
 	}
 
-	bctx.SetClaims(idt.Identity)
-
+	// Otherwise, we return the computed action.
 	return action, nil
 }
 


### PR DESCRIPTION
/permissions is a abit complex and allows people to ask perms for any set of clains, making is a bit cumbersome to use and remember what needs to be given.

This patch lets the user not set the claims or namespace into the permissions object. In that case the current token and/or current X-Namespace will be used (and reported back).

It also requires a little change in the authenticator to always try to parse the token, even if the resource is marked as public. So this way, if a public resource is accessed by a logged user, the processor can still access the caller's claims.