### PR TITLE
oauth: persist OAuth application through auth code exchange

### DIFF
--- a/pkgs/token/token.go
+++ b/pkgs/token/token.go
@@ -55,7 +55,7 @@ type IdentityToken struct {
 
 	// Information relative to the oauth application used to
 	// mint bearer's token.
-	OAuthApplication OAuthApplication `json:"-"`
+	OAuthApplication OAuthApplication `json:"oauthapplication,omitempty"`
 
 	jwt.RegisteredClaims
 }


### PR DESCRIPTION
Serialize OAuth application data on identity tokens so it survives the /issue to /oauth/token round trip and final access tokens keep their @oauthapp:* claims.

Fixes: 33f25e9ecd3d ("token: stamp issued tokens with OAuth application identity")