### PR TITLE
pkgs/token: support OAuth server metadata in JWKS discovery

### DIFF
--- a/pkgs/authenticator/authenticator_test.go
+++ b/pkgs/authenticator/authenticator_test.go
@@ -404,6 +404,11 @@ func TestHandleFederatedToken(t *testing.T) {
 
 			var called int
 			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.URL.Path != "/.well-known/jwks.json" {
+					http.NotFound(w, req)
+					return
+				}
+
 				called++
 				j := token.NewJWKS()
 				j.Append(c2) // nolint

--- a/pkgs/token/utils.go
+++ b/pkgs/token/utils.go
@@ -5,8 +5,10 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -81,16 +83,24 @@ func Fingerprint(cert *x509.Certificate) string {
 func JWKSFromTokenIssuer(ctx context.Context, idt *IdentityToken, tlsConfig *tls.Config) (*JWKS, error) {
 
 	wellKnownSuffix := ".well-known/jwks.json"
-
-	endpoint := idt.Issuer
-	if !strings.HasSuffix(endpoint, wellKnownSuffix) {
-		endpoint = fmt.Sprintf("%s/%s", strings.TrimRight(endpoint, "/"), wellKnownSuffix)
-	}
-
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},
+	}
+
+	endpoint := idt.Issuer
+	if !strings.HasSuffix(endpoint, wellKnownSuffix) {
+		if discovered, err := oauthJWKSURL(ctx, endpoint, client); err == nil {
+			endpoint = discovered
+		} else {
+			u, err := url.Parse(endpoint)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse issuer url: %w", err)
+			}
+			u.Path = wellKnownSuffix
+			endpoint = u.String()
+		}
 	}
 
 	jwks, err := NewRemoteJWKS(ctx, client, endpoint)
@@ -99,6 +109,50 @@ func JWKSFromTokenIssuer(ctx context.Context, idt *IdentityToken, tlsConfig *tls
 	}
 
 	return jwks, nil
+}
+
+func oauthJWKSURL(ctx context.Context, issuer string, client *http.Client) (string, error) {
+
+	u, err := url.Parse(issuer)
+	if err != nil {
+		return "", err
+	}
+
+	u.Path = "/.well-known/oauth-authorization-server" + u.EscapedPath()
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() // nolint
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid status code: %s", resp.Status)
+	}
+
+	var metadata struct {
+		Issuer  string `json:"issuer"`
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+		return "", err
+	}
+	if metadata.Issuer != issuer {
+		return "", fmt.Errorf("invalid issuer %q", metadata.Issuer)
+	}
+	if metadata.JWKSURI == "" {
+		return "", fmt.Errorf("missing jwks_uri")
+	}
+
+	return metadata.JWKSURI, nil
 }
 
 func makeKeyFunc(keychain *JWKS) jwt.Keyfunc {

--- a/pkgs/token/utils_test.go
+++ b/pkgs/token/utils_test.go
@@ -257,4 +257,98 @@ func TestJWKSFromTokenIssuer(t *testing.T) {
 			So(jwks.Keys[0].y, ShouldHaveSameTypeAs, big.NewInt(42))
 		})
 	})
+
+	Convey("given an issuer with RFC 8414 metadata", t, func() {
+
+		var serverURL string
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/.well-known/oauth-authorization-server/oauth/team":
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"issuer":   serverURL + "/oauth/team",
+					"jwks_uri": serverURL + "/jwks",
+				})
+			case "/jwks":
+				j := NewJWKS()
+				j.Keys = []*JWKSKey{
+					{
+						KID: "kid",
+						X:   "vs1LjF38O2OOSmy0Nbo45zfroQ1ME7GLuZ69uuiCOkk",
+						Y:   "vs1LjF38O2OOSmy0Nbo45zfroQ1ME7GLuZ69uuiCOkk",
+					},
+				}
+				d, _ := json.Marshal(j)
+				w.Write(d) // nolint
+			default:
+				http.NotFound(w, req)
+			}
+		}))
+		serverURL = ts.URL
+
+		idt := &IdentityToken{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Issuer: ts.URL + "/oauth/team",
+			},
+		}
+
+		jwks, err := JWKSFromTokenIssuer(
+			context.Background(),
+			idt,
+			&tls.Config{
+				MinVersion:         tls.VersionTLS13,
+				InsecureSkipVerify: true, // nolint
+			},
+		)
+
+		So(err, ShouldBeNil)
+		So(len(jwks.Keys), ShouldEqual, 1)
+	})
+
+	Convey("given an issuer without metadata, fallback should use root well-known jwks", t, func() {
+
+		var requestedPaths []string
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			requestedPaths = append(requestedPaths, req.URL.Path)
+
+			switch req.URL.Path {
+			case "/.well-known/oauth-authorization-server/oauth/team":
+				http.NotFound(w, req)
+			case "/.well-known/jwks.json":
+				j := NewJWKS()
+				j.Keys = []*JWKSKey{
+					{
+						KID: "kid",
+						X:   "vs1LjF38O2OOSmy0Nbo45zfroQ1ME7GLuZ69uuiCOkk",
+						Y:   "vs1LjF38O2OOSmy0Nbo45zfroQ1ME7GLuZ69uuiCOkk",
+					},
+				}
+				d, _ := json.Marshal(j)
+				w.Write(d) // nolint
+			default:
+				http.NotFound(w, req)
+			}
+		}))
+
+		idt := &IdentityToken{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Issuer: ts.URL + "/oauth/team",
+			},
+		}
+
+		jwks, err := JWKSFromTokenIssuer(
+			context.Background(),
+			idt,
+			&tls.Config{
+				MinVersion:         tls.VersionTLS13,
+				InsecureSkipVerify: true, // nolint
+			},
+		)
+
+		So(err, ShouldBeNil)
+		So(len(jwks.Keys), ShouldEqual, 1)
+		So(requestedPaths, ShouldResemble, []string{
+			"/.well-known/oauth-authorization-server/oauth/team",
+			"/.well-known/jwks.json",
+		})
+	})
 }


### PR DESCRIPTION
Teach issuer-based JWKS discovery to use OAuth authorization server metadata and keep the existing /.well-known/jwks.json endpoint as a compatibility fallback.

This fixes verification for issuers with path components, for example:
- https://host/oauth
- https://host/oauth/L29yZ3MvYWN1dml0eS5haQ

Previously, discovery could fall back to appending /.well-known/jwks.json to the issuer path, producing incorrect URLs such as:
- https://host/oauth/.well-known/jwks.json
- https://host/oauth/<ns>/.well-known/jwks.json

The new behavior is:
- try OAuth authorization server metadata first
- use metadata jwks_uri when present
- otherwise fall back to the legacy host-root JWKS endpoint: /.well-known/jwks.json (without the path component)

Do this per RFC 8414 [1], which defines metadata lookup by inserting /.well-known/oauth-authorization-server between the host and issuer path.

[1] https://www.rfc-editor.org/rfc/rfc8414.html#section-3.1