### PR TITLE
api: do not validate URL

### DIFF
--- a/pkgs/api/custom_validations.go
+++ b/pkgs/api/custom_validations.go
@@ -197,6 +197,10 @@ func ValidateIssue(iss *Issue) error {
 // ValidateURL validates the given value is a correct url.
 func ValidateURL(attribute string, u string) error {
 
+	if len(u) == 0 {
+		return nil
+	}
+
 	uu, err := url.Parse(u)
 	if err != nil {
 		return makeErr(attribute, fmt.Sprintf("invalid url: %s", err))

--- a/pkgs/api/custom_validations_test.go
+++ b/pkgs/api/custom_validations_test.go
@@ -1201,6 +1201,17 @@ func TestValidateURL(t *testing.T) {
 			true,
 			nil,
 		},
+		{
+			"empty",
+			func(t *testing.T) args {
+				return args{
+					"attr",
+					"",
+				}
+			},
+			false,
+			nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Validation function should skip validating something with a 0 values. Forcing to set something is controlled by "required: true", not a custom validation.