### PR TITLE
oauth: omit empty OAuth Application claims in tokens

### DIFF
--- a/pkgs/token/token.go
+++ b/pkgs/token/token.go
@@ -55,7 +55,7 @@ type IdentityToken struct {
 
 	// Information relative to the oauth application used to
 	// mint bearer's token.
-	OAuthApplication OAuthApplication `json:"oauthapplication,omitempty"`
+	OAuthApplication OAuthApplication `json:"oauthapplication,omitempty,omitzero"`
 
 	jwt.RegisteredClaims
 }


### PR DESCRIPTION
Tokens created via non-oauth flows retain an empty oauthapplication object in the token, i.e:
{
  ...
  "oauthapplication": {
    "ID": "",
    "Namespace": "",
    "Name": ""
  },
  ...
}

Avoid this by setting "omitzero" in oauth application serialization.

Fixes: 7293da1d4716 ("oauth: persist OAuth application through auth code exchange")