### PR TITLE
oauth: fix issuer base URL for OAuth applications

### DIFF
--- a/cmd/a3s/main.go
+++ b/cmd/a3s/main.go
@@ -535,7 +535,11 @@ func main() {
 		slog.Error("Unable to initialize redis oauthserver store", err)
 		os.Exit(1)
 	}
-	oauth := oauthserver.NewOAuth(oauthStore, m, jwks, publicAPIEndpoint, cfg.JWT.JWTDefaultValidity)
+	oauth, err := oauthserver.NewOAuth(oauthStore, m, jwks, cfg.JWT.JWTIssuer, cfg.JWT.JWTDefaultValidity)
+	if err != nil {
+		slog.Error("Unable to initialize oauthserver", err)
+		os.Exit(1)
+	}
 	oauthHTTPHandler := oauthserver.NewHTTPHandler(
 		oauth,
 		cfg.OAuth.OAuthUIEndpoint,

--- a/internal/oauthserver/oauth.go
+++ b/internal/oauthserver/oauth.go
@@ -48,8 +48,11 @@ const (
 )
 
 // NewOAuth returns a new OAuth engine.
-func NewOAuth(store oauthStore, manipulator manipulate.Manipulator, jwks *token.JWKS, baseURL *url.URL, validity time.Duration) *OAuth {
-	issuerURL := *baseURL
+func NewOAuth(store oauthStore, manipulator manipulate.Manipulator, jwks *token.JWKS, baseURL string, validity time.Duration) (*OAuth, error) {
+	issuerURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
 	issuerURL.Path = issuerURL.Path + "/oauth"
 	issuerURL.RawPath = ""
 	issuerURL.RawQuery = ""
@@ -58,9 +61,9 @@ func NewOAuth(store oauthStore, manipulator manipulate.Manipulator, jwks *token.
 		store:     store,
 		m:         manipulator,
 		jwks:      jwks,
-		issuerURL: &issuerURL,
+		issuerURL: issuerURL,
 		validity:  validity,
-	}
+	}, nil
 }
 
 func (o *OAuth) getClient(ctx context.Context, namespace string, clientID string) (*api.OAuthClient, error) {


### PR DESCRIPTION
OAuth applications issuer needs to be based on the external URL A3S is served from. This was wrongfully using "publicAPIEndpoint" which is currently using an internal endpoint.

Base the OAuth issuer on the "issuer" configuration which is the base for other tokens.

Fixes: 31dfc2036ae83 ("main: register embedded OAuth server")