### PR TITLE
authenticator: allow specifying an issuer an CheckAuthentication

### DIFF
--- a/pkgs/authenticator/authenticator.go
+++ b/pkgs/authenticator/authenticator.go
@@ -69,6 +69,10 @@ func (a *Authenticator) AuthenticateSession(session bahamut.Session) (bahamut.Au
 	return action, nil
 }
 
+func (a *Authenticator) Issuer() string {
+	return a.issuer
+}
+
 // AuthenticateRequest authenticates the request from the given bahamut.Context.
 func (a *Authenticator) AuthenticateRequest(bctx bahamut.Context) (bahamut.AuthAction, error) {
 
@@ -104,7 +108,12 @@ func (a *Authenticator) AuthenticateRequest(bctx bahamut.Context) (bahamut.AuthA
 }
 
 // CheckAuthentication authenticates the given JWT string.
-func (a *Authenticator) CheckAuthentication(ctx context.Context, tokenString string) (bahamut.AuthAction, *token.IdentityToken, error) {
+func (a *Authenticator) CheckAuthentication(ctx context.Context, tokenString string, options ...CheckOption) (bahamut.AuthAction, *token.IdentityToken, error) {
+
+	cfg := checkConfig{}
+	for _, o := range options {
+		o(&cfg)
+	}
 
 	if tokenString == "" {
 		return bahamut.AuthActionKO, nil, elemental.NewError(
@@ -117,6 +126,9 @@ func (a *Authenticator) CheckAuthentication(ctx context.Context, tokenString str
 
 	jwks := a.jwks
 	issuer := a.issuer
+	if cfg.issuer != "" {
+		issuer = cfg.issuer
+	}
 
 	rjwks, rissuer, err := a.handleFederatedToken(ctx, tokenString)
 	if err != nil {

--- a/pkgs/authenticator/authenticator_test.go
+++ b/pkgs/authenticator/authenticator_test.go
@@ -105,6 +105,26 @@ func TestCommonAuth(t *testing.T) {
 			So(idt.Identity, ShouldResemble, []string{"color=blue", "@source:type=test"})
 		})
 
+		Convey("Calling commonAuth with an issuer option should work", func() {
+			iss := "other-iss"
+
+			token := makeToken(
+				&token.IdentityToken{
+					RegisteredClaims: jwt.RegisteredClaims{Issuer: iss},
+					Identity:         []string{"color=blue", "@source:type=test"},
+				},
+				jwt.SigningMethodES256,
+				k,
+				kid1,
+			)
+
+			action, idt, err := a.CheckAuthentication(context.Background(), token, CheckOptionIssuer(iss))
+
+			So(err, ShouldBeNil)
+			So(action, ShouldEqual, bahamut.AuthActionContinue)
+			So(idt.Identity, ShouldResemble, []string{"color=blue", "@source:type=test"})
+		})
+
 		Convey("Calling commonAuth on a refresh token should fail", func() {
 
 			token := makeToken(

--- a/pkgs/authenticator/options.go
+++ b/pkgs/authenticator/options.go
@@ -31,3 +31,18 @@ func OptionExternalTrustedIssuers(issuers ...RemoteIssuer) Option {
 		cfg.externalTrustedIssuers = issuers
 	}
 }
+
+type checkConfig struct {
+	issuer string
+}
+
+// An CheckOption can be used to configure various options in the
+// CheckAuthentication.
+type CheckOption func(*checkConfig)
+
+// OptionIssuer sets an issuer to be used on CheckAuthentication
+func CheckOptionIssuer(issuer string) CheckOption {
+	return func(cfg *checkConfig) {
+		cfg.issuer = issuer
+	}
+}

--- a/pkgs/authenticator/options_test.go
+++ b/pkgs/authenticator/options_test.go
@@ -22,3 +22,12 @@ func TestOption(t *testing.T) {
 		So(cfg.externalTrustedIssuers, ShouldResemble, []RemoteIssuer{i1, i2})
 	})
 }
+
+func TestCheckOption(t *testing.T) {
+
+	Convey("CheckOptionIssuer should work", t, func() {
+		cfg := &checkConfig{}
+		CheckOptionIssuer("issuer1")(cfg)
+		So(cfg.issuer, ShouldEqual, "issuer1")
+	})
+}


### PR DESCRIPTION
Allow callers to override the authenticator issuer when validating tokens. This is useful for OAuth flows where the issuer includes the namespace but we still want to use the same authenticator instance (with the same JWKS).

Also expose the authenticator issuer via an "Issuer()" method so the caller can derive the issuer from the original issuer.