### PR TITLE
lombric: support keyed collections in config flags

### DIFF
--- a/pkgs/lombric/lombric.go
+++ b/pkgs/lombric/lombric.go
@@ -45,7 +45,7 @@ type VersionPrinter interface {
 // Initialize does all the basic job of bindings
 func Initialize(conf Configurable) {
 
-	requiredFlags, secretFlags, allowedValues, filesValues := installFlags(conf)
+	requiredFlags, secretFlags, allowedValues, filesValues, mapFlags := installFlags(conf)
 
 	pflag.VisitAll(func(f *pflag.Flag) {
 
@@ -103,6 +103,10 @@ func Initialize(conf Configurable) {
 
 		for _, key := range filesValues {
 
+			if stringInSlice(key, mapFlags) {
+				continue // resolved per-entry in the mapFlags loop below
+			}
+
 			value := viper.GetString(key)
 
 			if strings.HasPrefix(value, "file://") {
@@ -112,18 +116,40 @@ func Initialize(conf Configurable) {
 					panic(fmt.Sprintf("invalid url for secret: %s", err))
 				}
 
-				data, err := os.ReadFile(u.Path)
+				content, err := resolveSecretFile(u)
 				if err != nil {
-					panic(fmt.Sprintf("unable to read secret file for key '%s': %s", key, err))
+					panic(fmt.Sprintf("unable to resolve secret file for key '%s': %s", key, err))
 				}
-				viper.Set(key, string(bytes.TrimSpace(data)))
 
-				if u.Query().Get("delete") != "" {
-					if err := os.Remove(u.Path); err != nil {
-						panic(fmt.Sprintf("unable to delete secret file: %s", err))
-					}
-				}
+				viper.Set(key, content)
 			}
+		}
+
+		for _, key := range mapFlags {
+
+			parsed, err := parseStringToStringMap(viper.GetString(key))
+			if err != nil {
+				panic(fmt.Sprintf("invalid map value for '%s': %s", key, err))
+			}
+
+			isFile := stringInSlice(key, filesValues)
+			m := make(map[string]string, len(parsed))
+
+			for k, u := range parsed {
+
+				if !isFile || u.Scheme != "file" {
+					m[k] = u.String()
+					continue
+				}
+
+				content, err := resolveSecretFile(u)
+				if err != nil {
+					panic(fmt.Sprintf("unable to resolve secret file for map key '%s': %s", key, err))
+				}
+				m[k] = content
+			}
+
+			viper.Set(key, m)
 		}
 	}
 
@@ -140,6 +166,44 @@ func Initialize(conf Configurable) {
 			}
 		}
 	}
+}
+
+func resolveSecretFile(u *url.URL) (string, error) {
+
+	data, err := os.ReadFile(u.Path)
+	if err != nil {
+		return "", err
+	}
+
+	if u.Query().Get("delete") != "" {
+		if err := os.Remove(u.Path); err != nil {
+			return "", err
+		}
+	}
+
+	return string(bytes.TrimSpace(data)), nil
+}
+
+func parseStringToStringMap(s string) (map[string]*url.URL, error) {
+	m := make(map[string]*url.URL)
+	if s == "" {
+		return m, nil
+	}
+	for _, entry := range strings.Fields(s) {
+
+		id, value, found := strings.Cut(entry, ":")
+		if !found || id == "" {
+			return nil, fmt.Errorf("invalid entry %q: missing 'id:' prefix", entry)
+		}
+
+		u, err := url.Parse(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid entry %q: %w", entry, err)
+		}
+
+		m[id] = u
+	}
+	return m, nil
 }
 
 func deepFields(ift reflect.Type) ([]reflect.StructField, []string) {
@@ -171,7 +235,7 @@ func deepFields(ift reflect.Type) ([]reflect.StructField, []string) {
 	return fields, overrides
 }
 
-func installFlags(conf Configurable) (requiredFlags []string, secretFlags []string, allowedValues map[string][]string, fromFilesFlags []string) {
+func installFlags(conf Configurable) (requiredFlags []string, secretFlags []string, allowedValues map[string][]string, fromFilesFlags []string, mapFlags []string) {
 
 	t := reflect.ValueOf(conf).Elem().Type()
 
@@ -221,6 +285,15 @@ func installFlags(conf Configurable) (requiredFlags []string, secretFlags []stri
 
 		if field.Tag.Get("hidden") == enabledKey {
 			hiddenFlags = append(hiddenFlags, key)
+		}
+
+		if field.Type.Kind() == reflect.Map {
+			if field.Type.Key().Kind() != reflect.String || field.Type.Elem().Kind() != reflect.String {
+				panic("Unsupported map type: " + field.Type.String())
+			}
+			mapFlags = append(mapFlags, key)
+			pflag.String(key, def, description)
+			continue
 		}
 
 		if field.Type.Kind() != reflect.Slice {
@@ -314,5 +387,5 @@ func installFlags(conf Configurable) (requiredFlags []string, secretFlags []stri
 
 	pflag.Parse()
 
-	return requiredFlags, secretFlags, allowedValues, fromFilesFlags
+	return requiredFlags, secretFlags, allowedValues, fromFilesFlags, mapFlags
 }

--- a/pkgs/lombric/lombric_test.go
+++ b/pkgs/lombric/lombric_test.go
@@ -27,25 +27,27 @@ func init() {
 }
 
 type testConf struct {
-	ABool                   bool          `mapstructure:"a-bool"                    desc:"This is a boolean"            default:"true"`
-	ARequiredBool           bool          `mapstructure:"a-required-bool"           desc:"This is a boolean"            required:"true"`
-	ABoolNoDef              bool          `mapstructure:"a-bool-nodef"              desc:"This is a no def boolean"     `
-	ABoolSlice              []bool        `mapstructure:"a-bool-slice"              desc:"This is a bool slice"         default:"true,false,true"`
-	ADuration               time.Duration `mapstructure:"a-duration"                desc:"This is a duration"           default:"10s"`
-	ADurationNoDef          time.Duration `mapstructure:"a-duration-nodef"          desc:"This is a no def duration"    `
-	AInteger                int           `mapstructure:"a-integer"                 desc:"This is a number"             default:"42"`
-	AIntegerNoDef           int           `mapstructure:"a-integer-nodef"           desc:"This is a no def number"      `
-	AIntSlice               []int         `mapstructure:"a-int-slice"               desc:"This is a int slice"          default:"1,2,3"`
-	AnEnum                  string        `mapstructure:"a-enum"                    desc:"This is an enum"              allowed:"a,b,c" default:"a"`
-	AnIPSlice               []net.IP      `mapstructure:"a-ip-slice"                desc:"This is an ip slice"          default:"127.0.0.1,192.168.100.1"`
-	AnotherStringSliceNoDef []string      `mapstructure:"a-string-slice-from-var"   desc:"This is a no def string"      `
-	ASecret                 string        `mapstructure:"a-secret-from-var"         desc:"This is a secret"             secret:"true"`
-	AString                 string        `mapstructure:"a-string"                  desc:"This is a string"             default:"hello"`
-	AStringNoDef            string        `mapstructure:"a-string-nodef"            desc:"This is a no def string"      `
-	AStringSlice            []string      `mapstructure:"a-string-slice"            desc:"This is a string slice"       default:"a,b,c"`
-	AStringSliceNoDef       []string      `mapstructure:"a-string-slice-nodef"      desc:"This is a no def string slice"`
-	ASimpleFromFile         string        `mapstructure:"a-simple-from-file"        desc:"This is a simple from file"   file:"true"`
-	ASimpleFromFileDelete   string        `mapstructure:"a-simple-from-file-del"    desc:"This is a simple from file"   file:"true"`
+	ABool                   bool              `mapstructure:"a-bool"                    desc:"This is a boolean"            default:"true"`
+	ARequiredBool           bool              `mapstructure:"a-required-bool"           desc:"This is a boolean"            required:"true"`
+	ABoolNoDef              bool              `mapstructure:"a-bool-nodef"              desc:"This is a no def boolean"     `
+	ABoolSlice              []bool            `mapstructure:"a-bool-slice"              desc:"This is a bool slice"         default:"true,false,true"`
+	ADuration               time.Duration     `mapstructure:"a-duration"                desc:"This is a duration"           default:"10s"`
+	ADurationNoDef          time.Duration     `mapstructure:"a-duration-nodef"          desc:"This is a no def duration"    `
+	AInteger                int               `mapstructure:"a-integer"                 desc:"This is a number"             default:"42"`
+	AIntegerNoDef           int               `mapstructure:"a-integer-nodef"           desc:"This is a no def number"      `
+	AIntSlice               []int             `mapstructure:"a-int-slice"               desc:"This is a int slice"          default:"1,2,3"`
+	AnEnum                  string            `mapstructure:"a-enum"                    desc:"This is an enum"              allowed:"a,b,c" default:"a"`
+	AnIPSlice               []net.IP          `mapstructure:"a-ip-slice"                desc:"This is an ip slice"          default:"127.0.0.1,192.168.100.1"`
+	AnotherStringSliceNoDef []string          `mapstructure:"a-string-slice-from-var"   desc:"This is a no def string"      `
+	ASecret                 string            `mapstructure:"a-secret-from-var"         desc:"This is a secret"             secret:"true"`
+	AString                 string            `mapstructure:"a-string"                  desc:"This is a string"             default:"hello"`
+	AStringNoDef            string            `mapstructure:"a-string-nodef"            desc:"This is a no def string"      `
+	AStringSlice            []string          `mapstructure:"a-string-slice"            desc:"This is a string slice"       default:"a,b,c"`
+	AStringSliceNoDef       []string          `mapstructure:"a-string-slice-nodef"      desc:"This is a no def string slice"`
+	ASimpleFromFile         string            `mapstructure:"a-simple-from-file"        desc:"This is a simple from file"   file:"true"`
+	ASimpleFromFileDelete   string            `mapstructure:"a-simple-from-file-del"    desc:"This is a simple from file"   file:"true"`
+	AStringToStringMap      map[string]string `mapstructure:"a-string-to-string-map"    desc:"This is a map"                secret:"true" file:"true"`
+	APlainStringToStringMap map[string]string `mapstructure:"a-plain-string-to-string-map" desc:"This is a plain map"`
 
 	embedTestConf `mapstructure:",squash" override:"embedded-string-a=outter1,embedded-ignored-string=-"`
 }
@@ -85,11 +87,23 @@ func TestLombric_Initialize(t *testing.T) {
 		spath2 := fmt.Sprintf("file://%s?delete=true", sfile2.Name())
 
 		conf := &testConf{}
+		sfile3, err := os.CreateTemp(os.TempDir(), "secret3")
+		if err != nil {
+			panic(err)
+		}
+		defer sfile3.Close() // nolint
+		if _, err := sfile3.WriteString("my-private-key\n\n"); err != nil {
+			panic(err)
+		}
+
 		os.Setenv("LOMBRIC_A_STRING_SLICE_FROM_VAR", "x y z") // nolint: errcheck
 		os.Setenv("LOMBRIC_A_REQUIRED_BOOL", "true")          // nolint: errcheck
 		os.Setenv("LOMBRIC_A_SECRET_FROM_VAR", "secret")      // nolint: errcheck
 		os.Setenv("LOMBRIC_A_SIMPLE_FROM_FILE", spath1)       // nolint: errcheck
 		os.Setenv("LOMBRIC_A_SIMPLE_FROM_FILE_DEL", spath2)   // nolint: errcheck
+		os.Setenv("LOMBRIC_A_STRING_TO_STRING_MAP",           // nolint: errcheck
+			fmt.Sprintf("key1:file://%s?delete=true key2:inline-value", sfile3.Name()))
+		os.Setenv("LOMBRIC_A_PLAIN_STRING_TO_STRING_MAP", "key1:val1 key2:val2") // nolint: errcheck
 
 		Initialize(conf)
 
@@ -121,10 +135,24 @@ func TestLombric_Initialize(t *testing.T) {
 			So(os.Getenv("LOMBRIC_A_SECRET_FROM_VAR"), ShouldEqual, "")
 			So(viper.AllKeys(), ShouldNotContain, "embedded-ignored-string")
 
+			So(conf.AStringToStringMap, ShouldResemble, map[string]string{
+				"key1": "my-private-key",
+				"key2": "inline-value",
+			})
+			So(os.Getenv("LOMBRIC_A_STRING_TO_STRING_MAP"), ShouldEqual, "")
+
+			So(conf.APlainStringToStringMap, ShouldResemble, map[string]string{
+				"key1": "val1",
+				"key2": "val2",
+			})
+
 			_, err := os.Stat(sfile1.Name())
 			So(os.IsNotExist(err), ShouldBeFalse)
 
 			_, err = os.Stat(sfile2.Name())
+			So(os.IsNotExist(err), ShouldBeTrue)
+
+			_, err = os.Stat(sfile3.Name())
 			So(os.IsNotExist(err), ShouldBeTrue)
 		})
 	})


### PR DESCRIPTION
Add support for map[string]string in config structs so callers can
express a keyed collection of values in a single flag.

The wire format is space-separated entries, each prefixed with its
key up to the first colon, e.g. "ID1:VALUE1 ID2:VALUE2". Cutting only
on the first colon keeps the id separate from the value even when the
value is itself a URL with a scheme (file://) or its own query string
(such as file:// secrets with ?delete=true).

When a map field carries file:"true", each entry is resolved
independently: if its value has a file:// scheme, lombric reads the
referenced file, replaces the value in memory, and removes the file
when delete=true is present in the query. Entries that aren't file://
URLs pass through unchanged, so a single map can mix file-backed and
plain values; a map field without file:"true" at all works the same
way, since every entry then takes that passthrough path. The env var
is scrubbed at startup as usual when secret:"true" is set. File
resolution stays gated on file:"true", consistent with how scalar
fields behave - map:string entries that merely look like file:// URLs
are left alone unless the field opted in.

That gating matters for the scalar loop too: fields tagged file:"true"
are collected into filesValues regardless of kind, so a map field's
raw multi-entry string could reach the scalar loop and get
misinterpreted as a single file:// URL (its wire format can itself
start with "file://" after the id prefix), corrupting or deleting the
wrong file before the dedicated map loop ever ran. The scalar loop now
skips keys that are also map flags, leaving their resolution entirely
to the map loop below it. The actual "read file, delete if requested"
logic is factored into a resolveSecretFile helper shared by both loops
instead of being duplicated.

Map fields are registered internally as pflag.String. The raw string
is parsed and written back as map[string]string before
viper.Unmarshal, so mapstructure receives a typed map rather than a
string.