### PR TITLE
lombric: adding Redact and RedactedJSON functions

### DIFF
--- a/pkgs/lombric/redact.go
+++ b/pkgs/lombric/redact.go
@@ -1,0 +1,244 @@
+// Copyright 2026 Proofpoint Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lombric
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// redactedValue is the placeholder substituted for the value of any struct
+// field tagged with `secret:"true"` when redacting via [Redact].
+const redactedValue = "[REDACTED]"
+
+var (
+	jsonMarshalerType = reflect.TypeFor[json.Marshaler]()
+	textMarshalerType = reflect.TypeFor[encoding.TextMarshaler]()
+)
+
+// Redact returns an encoder-neutral value tree (maps, slices and scalars)
+// mirroring what an encoder such as encoding/json or a YAML marshaller would
+// produce for conf, except that the value of every struct field carrying the
+// `secret:"true"` struct tag is replaced by "[REDACTED]" (redactedValue).
+//
+// Object keys are taken from the `mapstructure` tag (the tag lombric already
+// uses to bind flags and environment variables), so the redacted output reads
+// with the same keys an operator sets on the command line or in the
+// environment. Fields with no `mapstructure` tag (or `mapstructure:"-"`) are
+// omitted, matching lombric's own notion of what is a configuration key.
+// Sub-configurations inlined with `mapstructure:",squash"` are promoted into
+// their parent, so the result is as flat as the flag namespace itself.
+func Redact(conf Configurable) any {
+	return redact(reflect.ValueOf(conf))
+}
+
+// RedactedJSON marshals the redacted tree returned by [Redact] to JSON.
+func RedactedJSON(conf Configurable) ([]byte, error) {
+	return json.Marshal(Redact(conf))
+}
+
+// redact converts v into a value tree (maps, slices and scalars) mirroring what
+// an encoder would produce, with secret fields replaced by redactedValue.
+func redact(v reflect.Value) any {
+
+	if !v.IsValid() {
+		return nil
+	}
+
+	switch v.Kind() {
+
+	case reflect.Interface:
+		if v.IsNil() {
+			return nil
+		}
+		return redact(v.Elem())
+
+	case reflect.Pointer:
+		if v.IsNil() {
+			return nil
+		}
+		// A pointer type may be the one implementing the marshaler interface;
+		// preserve it before dereferencing.
+		if implementsMarshaler(v.Type()) {
+			return v.Interface()
+		}
+		return redact(v.Elem())
+	}
+
+	// Anything that knows how to marshal itself is emitted as-is. This both
+	// preserves its intended representation (e.g. time.Time -> RFC3339 string)
+	// and avoids reflecting into its unexported fields.
+	if implementsMarshaler(v.Type()) || (v.CanAddr() && implementsMarshaler(reflect.PointerTo(v.Type()))) {
+		return v.Interface()
+	}
+
+	switch v.Kind() {
+
+	case reflect.Struct:
+		out := map[string]any{}
+		addStructFields(v, out)
+		return out
+
+	case reflect.Slice:
+		if v.IsNil() {
+			return nil
+		}
+		// []byte and named byte slices marshal to a base64 string in
+		// encoding/json; keep that behaviour.
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			return v.Interface()
+		}
+		fallthrough
+
+	case reflect.Array:
+		out := make([]any, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			out[i] = redact(v.Index(i))
+		}
+		return out
+
+	case reflect.Map:
+		if v.IsNil() {
+			return nil
+		}
+		out := make(map[string]any, v.Len())
+		iter := v.MapRange()
+		for iter.Next() {
+			out[fmt.Sprint(iter.Key().Interface())] = redact(iter.Value())
+		}
+		return out
+
+	default:
+		return v.Interface()
+	}
+}
+
+// addStructFields walks the fields of struct value v, adding each to out under
+// its mapstructure name (redacting secrets), and inlining the fields of
+// sub-structs tagged `mapstructure:",squash"` to match how lombric flattens
+// embedded and named sub-configurations into a single flat key space.
+func addStructFields(v reflect.Value, out map[string]any) {
+
+	t := v.Type()
+
+	for i := 0; i < t.NumField(); i++ {
+
+		field := t.Field(i)
+
+		// Unexported, non-embedded fields cannot be read and are never config
+		// keys.
+		if field.PkgPath != "" && !field.Anonymous {
+			continue
+		}
+
+		name, squash, omitempty, skip := mapstructureName(field)
+		if skip {
+			continue
+		}
+
+		fv := v.Field(i)
+
+		// Inline the fields of a squashed sub-struct into the parent, just like
+		// lombric does when binding flags. Applies to both anonymous embeds and
+		// named fields (e.g. `JWT JWTConf `mapstructure:",squash"``).
+		if squash {
+			ev := fv
+			for ev.Kind() == reflect.Pointer {
+				if ev.IsNil() {
+					break
+				}
+				ev = ev.Elem()
+			}
+			if ev.Kind() == reflect.Struct && !implementsMarshaler(fv.Type()) {
+				addStructFields(ev, out)
+			}
+			continue
+		}
+
+		if omitempty && isEmptyValue(fv) {
+			continue
+		}
+
+		// Secrets are redacted regardless of their underlying type.
+		if field.Tag.Get("secret") == "true" {
+			out[name] = redactedValue
+			continue
+		}
+
+		out[name] = redact(fv)
+	}
+}
+
+// mapstructureName returns the object key for a struct field from its
+// `mapstructure` tag, whether it is squashed into its parent, whether it
+// carries the omitempty option, and whether it must be skipped entirely.
+//
+// A field with no `mapstructure` tag, or with `mapstructure:"-"`, is skipped:
+// lombric does not treat such fields as configuration keys.
+func mapstructureName(f reflect.StructField) (name string, squash bool, omitempty bool, skip bool) {
+
+	tag, ok := f.Tag.Lookup("mapstructure")
+	if !ok {
+		return "", false, false, true
+	}
+
+	// A bare "-" means skip; "-," means a field literally named "-".
+	if tag == "-" {
+		return "", false, false, true
+	}
+
+	parts := strings.Split(tag, ",")
+	name = parts[0]
+	for _, opt := range parts[1:] {
+		switch opt {
+		case "squash":
+			squash = true
+		case "omitempty":
+			omitempty = true
+		}
+	}
+
+	// A non-squashed field with an empty name carries no key: nothing to emit.
+	if name == "" && !squash {
+		return "", false, false, true
+	}
+
+	return name, squash, omitempty, false
+}
+
+// implementsMarshaler reports whether t implements json.Marshaler or
+// encoding.TextMarshaler.
+func implementsMarshaler(t reflect.Type) bool {
+	return t.Implements(jsonMarshalerType) || t.Implements(textMarshalerType)
+}
+
+// isEmptyValue mirrors encoding/json's notion of an empty value for omitempty.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Pointer:
+		return v.IsNil()
+	}
+	return false
+}

--- a/pkgs/lombric/redact_test.go
+++ b/pkgs/lombric/redact_test.go
@@ -1,0 +1,427 @@
+// Copyright 2026 Proofpoint Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lombric
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// marshalRedacted exercises the recursive redaction logic against purpose-built
+// fixtures, mirroring what RedactedJSON does.
+func marshalRedacted(v any) ([]byte, error) {
+	return json.Marshal(redact(reflect.ValueOf(v)))
+}
+
+func toMap(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	m := map[string]any{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("result is not a JSON object: %v (%s)", err, b)
+	}
+	return m
+}
+
+func TestRedact_TopLevelSecret(t *testing.T) {
+
+	type s struct {
+		Public string `mapstructure:"public"`
+		Secret string `mapstructure:"secret" secret:"true"`
+	}
+
+	b, err := marshalRedacted(s{Public: "visible", Secret: "s3cr3t"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+	if m["public"] != "visible" {
+		t.Errorf("public field mangled: got %v", m["public"])
+	}
+	if m["secret"] != redactedValue {
+		t.Errorf("secret not redacted: got %v", m["secret"])
+	}
+}
+
+func TestRedact_NestedStruct(t *testing.T) {
+
+	type inner struct {
+		Token string `mapstructure:"token" secret:"true"`
+		Keep  int    `mapstructure:"keep"`
+	}
+	type outer struct {
+		Inner inner `mapstructure:"inner"`
+	}
+
+	b, err := marshalRedacted(outer{Inner: inner{Token: "abc", Keep: 42}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+	in, ok := m["inner"].(map[string]any)
+	if !ok {
+		t.Fatalf("inner not an object: %v", m["inner"])
+	}
+	if in["token"] != redactedValue {
+		t.Errorf("nested secret not redacted: got %v", in["token"])
+	}
+	if in["keep"] != float64(42) {
+		t.Errorf("nested non-secret mangled: got %v", in["keep"])
+	}
+}
+
+func TestRedact_SquashInlining(t *testing.T) {
+
+	type embedded struct {
+		EmbeddedSecret string `mapstructure:"embedded-secret" secret:"true"`
+		EmbeddedPublic string `mapstructure:"embedded-public"`
+	}
+	type named struct {
+		NamedSecret string `mapstructure:"named-secret" secret:"true"`
+		NamedPublic string `mapstructure:"named-public"`
+	}
+	type outer struct {
+		embedded `mapstructure:",squash"`
+		Named    named  `mapstructure:",squash"`
+		Own      string `mapstructure:"own"`
+	}
+
+	b, err := marshalRedacted(outer{
+		embedded: embedded{EmbeddedSecret: "leak1", EmbeddedPublic: "ok1"},
+		Named:    named{NamedSecret: "leak2", NamedPublic: "ok2"},
+		Own:      "mine",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+
+	// Squashed sub-structs (anonymous and named) must be inlined, not nested.
+	if _, exists := m["Named"]; exists {
+		t.Errorf("squashed named field should be inlined, not nested: %v", m)
+	}
+	if _, exists := m["embedded"]; exists {
+		t.Errorf("squashed embed should be inlined, not nested: %v", m)
+	}
+
+	if m["embedded-secret"] != redactedValue {
+		t.Errorf("embedded secret not redacted: got %v", m["embedded-secret"])
+	}
+	if m["embedded-public"] != "ok1" {
+		t.Errorf("embedded public mangled: got %v", m["embedded-public"])
+	}
+	if m["named-secret"] != redactedValue {
+		t.Errorf("named-squashed secret not redacted: got %v", m["named-secret"])
+	}
+	if m["named-public"] != "ok2" {
+		t.Errorf("named-squashed public mangled: got %v", m["named-public"])
+	}
+	if m["own"] != "mine" {
+		t.Errorf("own field mangled: got %v", m["own"])
+	}
+	if strings.Contains(string(b), "leak") {
+		t.Errorf("cleartext secret leaked: %s", b)
+	}
+}
+
+func TestRedact_PointerFields(t *testing.T) {
+
+	type inner struct {
+		Pass string `mapstructure:"pass" secret:"true"`
+	}
+	type outer struct {
+		In     *inner  `mapstructure:"in"`
+		Nilptr *inner  `mapstructure:"nilptr"`
+		Sptr   *string `mapstructure:"sptr" secret:"true"`
+	}
+
+	secret := "hunter2"
+	b, err := marshalRedacted(outer{In: &inner{Pass: "pw"}, Sptr: &secret})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+	in, ok := m["in"].(map[string]any)
+	if !ok {
+		t.Fatalf("in not an object: %v", m["in"])
+	}
+	if in["pass"] != redactedValue {
+		t.Errorf("secret through pointer not redacted: got %v", in["pass"])
+	}
+	if m["nilptr"] != nil {
+		t.Errorf("nil pointer should marshal to null: got %v", m["nilptr"])
+	}
+	// A secret pointer field is redacted wholesale, never dereferenced.
+	if m["sptr"] != redactedValue {
+		t.Errorf("secret pointer not redacted: got %v", m["sptr"])
+	}
+}
+
+func TestRedact_SliceAndMapOfStructs(t *testing.T) {
+
+	type item struct {
+		Key string `mapstructure:"key" secret:"true"`
+		ID  int    `mapstructure:"id"`
+	}
+	type outer struct {
+		Items []item          `mapstructure:"items"`
+		ByKey map[string]item `mapstructure:"by-key"`
+	}
+
+	b, err := marshalRedacted(outer{
+		Items: []item{{Key: "k1", ID: 1}, {Key: "k2", ID: 2}},
+		ByKey: map[string]item{"a": {Key: "k3", ID: 3}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+
+	items, ok := m["items"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("items not a 2-element array: %v", m["items"])
+	}
+	for i, raw := range items {
+		it := raw.(map[string]any)
+		if it["key"] != redactedValue {
+			t.Errorf("items[%d] secret not redacted: got %v", i, it["key"])
+		}
+		if it["id"] != float64(i+1) {
+			t.Errorf("items[%d] id mangled: got %v", i, it["id"])
+		}
+	}
+
+	byKey := m["by-key"].(map[string]any)
+	if byKey["a"].(map[string]any)["key"] != redactedValue {
+		t.Errorf("map value secret not redacted: got %v", byKey["a"])
+	}
+}
+
+func TestRedact_DeeplyNestedSecret(t *testing.T) {
+
+	type l3 struct {
+		Deep string `mapstructure:"deep" secret:"true"`
+	}
+	type l2 struct {
+		L3 *l3 `mapstructure:"l3"`
+	}
+	type l1 struct {
+		L2 []l2 `mapstructure:"l2"`
+	}
+
+	b, err := marshalRedacted(l1{L2: []l2{{L3: &l3{Deep: "buried"}}}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+	deep := m["l2"].([]any)[0].(map[string]any)["l3"].(map[string]any)["deep"]
+	if deep != redactedValue {
+		t.Errorf("deeply nested secret not redacted: got %v", deep)
+	}
+	if strings.Contains(string(b), "buried") {
+		t.Errorf("cleartext secret leaked: %s", b)
+	}
+}
+
+func TestRedact_NonStringSecretRedactedAsString(t *testing.T) {
+
+	type s struct {
+		Numbers []int `mapstructure:"numbers" secret:"true"`
+		Count   int   `mapstructure:"count" secret:"true"`
+	}
+
+	b, err := marshalRedacted(s{Numbers: []int{1, 2, 3}, Count: 99})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+	// Regardless of the field's underlying type, a secret becomes the string
+	// placeholder.
+	if m["numbers"] != redactedValue {
+		t.Errorf("non-string (slice) secret not redacted: got %v", m["numbers"])
+	}
+	if m["count"] != redactedValue {
+		t.Errorf("non-string (int) secret not redacted: got %v", m["count"])
+	}
+}
+
+func TestRedact_SelfMarshalingTypePreserved(t *testing.T) {
+
+	type s struct {
+		When   time.Time `mapstructure:"when"`
+		Secret string    `mapstructure:"secret" secret:"true"`
+	}
+
+	ts := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	b, err := marshalRedacted(s{When: ts, Secret: "x"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+	// time.Time must keep its RFC3339 representation, not be decomposed into its
+	// unexported wall/ext/loc fields.
+	if m["when"] != ts.Format(time.RFC3339) {
+		t.Errorf("time.Time not preserved: got %v", m["when"])
+	}
+	if m["secret"] != redactedValue {
+		t.Errorf("secret alongside marshaler not redacted: got %v", m["secret"])
+	}
+}
+
+func TestRedact_MapstructureTagOptions(t *testing.T) {
+
+	type s struct {
+		Renamed  string `mapstructure:"renamed-field"`
+		Skipped  string `mapstructure:"-"`
+		Omitted  string `mapstructure:"omitted,omitempty"`
+		Present  string `mapstructure:"present,omitempty"`
+		Untagged string // no mapstructure tag: not a config key
+		private  string //nolint:unused // exercises unexported field skipping
+	}
+
+	b, err := marshalRedacted(s{
+		Renamed:  "r",
+		Skipped:  "should-not-appear",
+		Present:  "here",
+		Untagged: "internal-state",
+		private:  "x",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+	if m["renamed-field"] != "r" {
+		t.Errorf("mapstructure rename not honored: %v", m)
+	}
+	if _, ok := m["Skipped"]; ok {
+		t.Errorf("mapstructure:\"-\" field should be skipped: %v", m)
+	}
+	if _, ok := m["omitted"]; ok {
+		t.Errorf("empty omitempty field should be omitted: %v", m)
+	}
+	if m["present"] != "here" {
+		t.Errorf("non-empty omitempty field should be present: %v", m)
+	}
+	if _, ok := m["Untagged"]; ok {
+		t.Errorf("field without mapstructure tag should be skipped: %v", m)
+	}
+	if _, ok := m["private"]; ok {
+		t.Errorf("unexported field should be skipped: %v", m)
+	}
+}
+
+func TestRedact_EdgeKinds(t *testing.T) {
+
+	type s struct {
+		NilSlice []string       `mapstructure:"nil-slice"`
+		NilMap   map[string]int `mapstructure:"nil-map"`
+		Bytes    []byte         `mapstructure:"bytes"`
+		Arr      [2]int         `mapstructure:"arr"`
+		Iface    any            `mapstructure:"iface"`
+	}
+
+	b, err := marshalRedacted(s{Bytes: []byte("hi"), Arr: [2]int{7, 8}, Iface: "x"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := toMap(t, b)
+	if m["nil-slice"] != nil {
+		t.Errorf("nil slice should marshal to null: got %v", m["nil-slice"])
+	}
+	if m["nil-map"] != nil {
+		t.Errorf("nil map should marshal to null: got %v", m["nil-map"])
+	}
+	// []byte marshals to base64, same as encoding/json ("hi" -> "aGk=").
+	if m["bytes"] != "aGk=" {
+		t.Errorf("[]byte should be base64: got %v", m["bytes"])
+	}
+	arr, ok := m["arr"].([]any)
+	if !ok || len(arr) != 2 || arr[0] != float64(7) || arr[1] != float64(8) {
+		t.Errorf("array mangled: got %v", m["arr"])
+	}
+	if m["iface"] != "x" {
+		t.Errorf("interface field mangled: got %v", m["iface"])
+	}
+}
+
+// jwtConf mirrors the shape of a real lombric sub-configuration squashed into a
+// parent (e.g. a3s' JWTConf), carrying a secret field.
+type jwtConf struct {
+	JWTIssuer  string `mapstructure:"jwt-issuer"`
+	JWTKeyPass string `mapstructure:"jwt-key-pass" secret:"true" file:"true"`
+}
+
+// realishConf mimics a lombric top-level Conf: flat mapstructure leaves plus a
+// squashed sub-configuration.
+type realishConf struct {
+	APIURL   string  `mapstructure:"api-url"`
+	APIToken string  `mapstructure:"api-token" secret:"true" file:"true"`
+	JWT      jwtConf `mapstructure:",squash"`
+}
+
+// TestRedactedJSON_RealishConf verifies the public entry point produces a flat,
+// mapstructure-keyed object with every secret redacted and no cleartext leak.
+func TestRedactedJSON_RealishConf(t *testing.T) {
+
+	c := &realishConf{
+		APIURL:   "https://api.example.com",
+		APIToken: "SENTINEL-api-token",
+		JWT: jwtConf{
+			JWTIssuer:  "https://issuer.example.com",
+			JWTKeyPass: "SENTINEL-jwt-key-pass",
+		},
+	}
+
+	b, err := RedactedJSON(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := string(b)
+	for _, sentinel := range []string{"SENTINEL-api-token", "SENTINEL-jwt-key-pass"} {
+		if strings.Contains(out, sentinel) {
+			t.Errorf("cleartext secret %q leaked into output: %s", sentinel, out)
+		}
+	}
+
+	m := toMap(t, b)
+
+	// Squashed sub-config keys are promoted to the top level (flat key space).
+	if _, ok := m["JWT"]; ok {
+		t.Errorf("squashed JWT sub-config should be inlined, not nested: %v", m)
+	}
+
+	if m["api-token"] != redactedValue {
+		t.Errorf("expected api-token to be redacted: got %v", m["api-token"])
+	}
+	if m["jwt-key-pass"] != redactedValue {
+		t.Errorf("expected squashed jwt-key-pass to be redacted: got %v", m["jwt-key-pass"])
+	}
+	if m["api-url"] != "https://api.example.com" {
+		t.Errorf("non-secret api-url should be preserved: got %v", m["api-url"])
+	}
+	if m["jwt-issuer"] != "https://issuer.example.com" {
+		t.Errorf("non-secret jwt-issuer should be preserved: got %v", m["jwt-issuer"])
+	}
+}


### PR DESCRIPTION
Implements `Redact(Configurable) any` and `RedactJSON(Configurable) ([]byte, error)` functions in lombric which are meant to pass a service configuration struct into it and return a fully redacted version of the original. The field names are taken from their mapstructure names so that they truly resolve more to configuration-like fields than Golang internal struct names.

For details: https://github.com/acuvity/acuvity/issues/4766

@primalmotion yes, this is AI generated :) I reviewed the code closely and it looks fine to me (and works well in apex-v2 already). Tested against this branch. The output looks like this now:

```
acuctl api list deploymentinstance --parent deployment/6a4d583d1a6a78a43e3a6eef
[
  {
    "ID": "6a4d589e1a6a78a43e3a6f1f",
    "config": "{\"acutracer-enable\":true,\"acutracer-tracestate-passphrase\":\"[REDACTED]\",\"analyzer-circuit-breaker-consecutive-failures\":5,\"analyzer-circuit-breaker-interval\":60000000000,\"analyzer-circuit-breaker-max-requests\":1,\"analyzer-circuit-breaker-timeout\":30000000000,\"analyzer-inband-share\":40,\"analyzer-max-concurrent-requests\":100,\"analyzer-max-concurrent-user-requests\":10,\"analyzer-max-payload-size\":0,\"analyzer-token\":\"[REDACTED]\",\"analyzer-url\":\"\",\"api-ca-cert\":\"/Users/mheese/src/acuvity/backend/dev/data/certificates/ca-chain-external.pem\",\"api-namespace\":\"/orgs/acuvity.ai\",\"api-token\":\"[REDACTED]\",\"api-url\":\"https://127.0.0.1:3443\",\"auto-tls-ca\":\"\",\"auto-tls-ca-key\":\"\",\"auto-tls-ca-key-pass\":\"[REDACTED]\",\"auto-tls-client-ca\":[],\"auto-tls-common-name\":\"\",\"auto-tls-disable\":false,\"auto-tls-dns\":[\"auto\"],\"auto-tls-ip\":[\"auto\"],\"cluster-listen\":\"\",\"cluster-passphrase\":\"[REDACTED]\",\"cluster-peer\":[],\"cors-additional-origins\":[],\"cors-default-origin\":\"\",\"dump-proxy-roundtrips\":false,\"dynamic-tls-ca\":\"/Users/mheese/src/acuvity/backend/dev/data/certificates/ca-chain-external.pem\",\"dynamic-tls-ca-key\":\"/Users/mheese/src/acuvity/backend/dev/data/certificates/ca-external-key.pem\",\"dynamic-tls-ca-pass\":\"[REDACTED]\",\"evaluation-mode\":false,\"exit-proxy\":[],\"fallback-namespace-suffix\":\"employees\",\"file-store\":\"file:///Users/mheese/src/acuvity/backend/dev/data/apexstorage\",\"file-store-passphrase\":\"[REDACTED]\",\"fingerprinting-resistance-enabled\":true,\"h2-disable\":false,\"har-filter-domain\":[],\"har-output-path\":\"/tmp\",\"health-enabled\":false,\"health-listen\":\":80\",\"inject-disabled\":false,\"inject-minified\":true,\"jwt-trusted-issuer\":\"\",\"listen\":\":1443\",\"log-format\":\"console\",\"log-level\":\"debug\",\"log-tracer\":\"127.0.0.1:6831\",\"max-conns\":0,\"max-procs\":0,\"mcp-oauth-store-encryption-key\":\"[REDACTED]\",\"private-api-url\":\"\",\"profiling-enabled\":false,\"profiling-listen\":\":6060\",\"proxy-auth-delay\":0,\"proxy-auth-delay-browser\":[],\"proxy-catch-all-directive\":\"DIRECT\",\"proxy-everything\":false,\"proxy-http-enable\":false,\"proxy-http-exposed-port\":0,\"proxy-http-listen\":\"0.0.0.0:8080\",\"proxy-https-enable\":true,\"proxy-https-exposed-port\":0,\"public-api-url\":\"https://apex.acumux:1443\",\"redis-address\":\"localhost:6380\",\"redis-db\":0,\"redis-dial-timeout\":30000000000,\"redis-pass\":\"[REDACTED]\",\"redis-pool-size\":0,\"redis-tls-ca\":\"/Users/mheese/src/acuvity/backend/dev/data/certificates/ca-chain-internal.pem\",\"redis-tls-cert\":\"/Users/mheese/src/acuvity/backend/dev/data/certificates/system-cert.pem\",\"redis-tls-key\":\"/Users/mheese/src/acuvity/backend/dev/data/certificates/system-key.pem\",\"redis-tls-key-pass\":\"[REDACTED]\",\"redis-user\":\"default\",\"restricted-cidr-egress\":[],\"restricted-cidr-egress-ignore\":[\"127.0.0.1/24\"],\"restricted-cidr-ingress\":[],\"restricted-cidr-ingress-ignore\":[],\"revocation-cache-ttl\":600000000000,\"scan-rate-limit-burst\":3,\"scan-rate-limit-enabled\":false,\"scan-rate-limit-rps\":1,\"single-user-mode\":false,\"tls-cert\":\"\",\"tls-client-ca\":[],\"tls-disable\":false,\"tls-key\":\"\",\"tls-key-pass\":\"[REDACTED]\",\"tunneling-enabled\":false,\"upstream-additional-ca\":[\"/Users/mheese/src/acuvity/backend/dev/data/certificates/acuprovider-cert.pem\"],\"ws-chan-read-size\":2048,\"ws-chan-write-size\":2048,\"xau-cidr\":[],\"xau-header\":\"X-Authenticated-User\",\"xau-trust\":false}",
    "currentVersion": "1.0.2 d090972a9 (darwin/arm64)",
    "hostname": "F971WT4RW9.corp.proofpoint.com",
    "namespace": "/orgs/acuvity.ai",
    "parentID": "6a4d583d1a6a78a43e3a6eef",
    "ping": "2026-07-09T03:53:10.646Z",
    "start": "2026-07-09T03:52:10.239Z",
    "status": "Alive",
    "tokenID": "8d3e2b37-0ec2-4039-9efe-69982fb14342"
  }
]
```