### PR TITLE
bootstrap/clients: log info about redis clients

### DIFF
--- a/cmd/a3s/main.go
+++ b/cmd/a3s/main.go
@@ -513,8 +513,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	slog.Info("Redis configured", "addr", cfg.RedisAddress, "db", cfg.RedisDB, "user", cfg.RedisUser)
-
 	redisClient, err := bootstrap.MakeRedisClient(cfg.RedisConf)
 	if err != nil {
 		slog.Info("Unable to connect to redis", err)

--- a/pkgs/bootstrap/clients.go
+++ b/pkgs/bootstrap/clients.go
@@ -329,6 +329,13 @@ func MakeRedisClient(cfg conf.RedisConf) (redis.UniversalClient, error) {
 		tlsConfig.RootCAs = pool
 	}
 
+	slog.Info("Redis configured",
+		"addr", cfg.RedisAddress,
+		"user", cfg.RedisUser,
+		"passw", cfg.RedisPassword != "",
+		"db", cfg.RedisDB,
+	)
+
 	return redis.NewClient(&redis.Options{
 		Addr:        cfg.RedisAddress,
 		Username:    cfg.RedisUser,

--- a/pkgs/bootstrap/clients.go
+++ b/pkgs/bootstrap/clients.go
@@ -286,54 +286,60 @@ func MakeA3SRemoteAuthX(
 // MakeRedisClient returns a redis client based on the provided configuration.
 func MakeRedisClient(cfg conf.RedisConf) (redis.UniversalClient, error) {
 
-	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS13,
-	}
+	var tlsConfig *tls.Config
 
-	if cfg.RedisTLSCert != "" {
-		cert, key, err := tglib.ReadCertificatePEM(
-			cfg.RedisTLSCert,
-			cfg.RedisTLSKey,
-			cfg.RedisTLSKeyPass,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read certificate: %w", err)
+	if !cfg.RedisDisableTLS {
+
+		tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS13,
 		}
 
-		clientCert, err := tglib.ToTLSCertificate(cert, key)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert client certificate: %w", err)
+		if cfg.RedisTLSCert != "" {
+			cert, key, err := tglib.ReadCertificatePEM(
+				cfg.RedisTLSCert,
+				cfg.RedisTLSKey,
+				cfg.RedisTLSKeyPass,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("unable to read certificate: %w", err)
+			}
+
+			clientCert, err := tglib.ToTLSCertificate(cert, key)
+			if err != nil {
+				return nil, fmt.Errorf("unable to convert client certificate: %w", err)
+			}
+
+			tlsConfig.Certificates = []tls.Certificate{clientCert}
 		}
 
-		tlsConfig.Certificates = []tls.Certificate{clientCert}
-	}
+		if cfg.RedisTLSCA == "" {
+			pool, err := x509.SystemCertPool()
+			if err != nil {
+				return nil, fmt.Errorf("unable to load system cert pool: %w", err)
+			}
 
-	if cfg.RedisTLSCA == "" {
-		pool, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, fmt.Errorf("unable to load system cert pool: %w", err)
+			tlsConfig.RootCAs = pool
+		} else {
+			data, err := os.ReadFile(cfg.RedisTLSCA)
+			if err != nil {
+				return nil, fmt.Errorf("unable to read CA file: %w", err)
+			}
+
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(data) {
+				return nil, fmt.Errorf("unable to append system signing ca")
+			}
+
+			tlsConfig.RootCAs = pool
 		}
-
-		tlsConfig.RootCAs = pool
-	} else {
-		data, err := os.ReadFile(cfg.RedisTLSCA)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read CA file: %w", err)
-		}
-
-		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM(data) {
-			return nil, fmt.Errorf("unable to append system signing ca")
-		}
-
-		tlsConfig.RootCAs = pool
 	}
 
 	slog.Info("Redis configured",
 		"addr", cfg.RedisAddress,
 		"user", cfg.RedisUser,
-		"passw", cfg.RedisPassword != "",
 		"db", cfg.RedisDB,
+		"passw", cfg.RedisPassword != "",
+		"tls", !cfg.RedisDisableTLS,
 	)
 
 	return redis.NewClient(&redis.Options{

--- a/pkgs/conf/conf.go
+++ b/pkgs/conf/conf.go
@@ -608,8 +608,9 @@ func (c *GatewayConf) GWHiddenAPIs() map[elemental.Identity]bool {
 
 type RedisConf struct {
 	RedisAddress     string        `mapstructure:"redis-address"      desc:"Network address for redis."                      `
-	RedisDialTimeout time.Duration `mapstructure:"redis-dial-timeout" desc:"Dial timeout for new connections to/from redis." default:"30s"`
 	RedisDB          int           `mapstructure:"redis-db"           desc:"Databse number for redis."                       default:"0"`
+	RedisDialTimeout time.Duration `mapstructure:"redis-dial-timeout" desc:"Dial timeout for new connections to/from redis." default:"30s"`
+	RedisDisableTLS  bool          `mapstructure:"redis-disable-tls"  desc:"If true, do not try to connect using TLS"`
 	RedisPassword    string        `mapstructure:"redis-pass"         desc:"Password for redis."                             secret:"true" file:"true"`
 	RedisPoolSize    int           `mapstructure:"redis-pool-size"    desc:"Socket pool size for redis."                     `
 	RedisTLSCA       string        `mapstructure:"redis-tls-ca"       desc:"The CA that redis is using"                      `


### PR DESCRIPTION
Previously redis config was not correctly logged.
Streaming MakeRedisClient to print info about the client it just configured.