### PR TITLE
issue: guard audit-metadata defer against nil idt

### DIFF
--- a/internal/processors/issue.go
+++ b/internal/processors/issue.go
@@ -315,7 +315,9 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 	}
 
 	defer func() {
-		bctx.SetMetadata(auditor.MetadataKeyAudit, idt.Identity)
+		if idt != nil {
+			bctx.SetMetadata(auditor.MetadataKeyAudit, idt.Identity)
+		}
 	}()
 
 	if err := idt.Restrict(permissions.Restrictions{


### PR DESCRIPTION
ProcessCreate reassigns idt from the plugin and binary modifier calls (`idt, err = p.pluginModifier.Token(...)`), and a modifier is free to return (nil, err) when it rejects the token.

In that case ProcessCreate returns immediately, but the deferred closure that stamps the audit metadata still runs and dereferences idt.Identity, turning a legitimate validation error into a nil pointer dereference panic instead of a clean 4xx/5xx response.

Skip the audit-metadata write when idt is nil rather than trying to recover a partial identity for it: the request is being rejected before an identity was finalized, so there is nothing meaningful to audit.