### PR TITLE
token: stamp issued tokens with OAuth client identity

### DIFF
--- a/internal/processors/issue.go
+++ b/internal/processors/issue.go
@@ -362,6 +362,13 @@ func (p *IssueProcessor) ProcessCreate(bctx bahamut.Context) (err error) {
 		}
 	}
 
+	if oauthClient != nil {
+		idt.OAuthClient = token.OAuthClient{
+			ClientID:  oauthClient.ClientID,
+			Namespace: oauthClient.Namespace,
+		}
+	}
+
 	originalSource := idt.Source
 	originalOAuthApplication := idt.OAuthApplication
 	if p.pluginModifier != nil {

--- a/pkgs/token/token.go
+++ b/pkgs/token/token.go
@@ -28,9 +28,9 @@ type Source struct {
 // An OAuthApplication represents the oauth application info
 // used to derive an IdentityToken.
 type OAuthApplication struct {
-	ID        string
-	Namespace string
-	Name      string
+	ID        string `json:"ID"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
 }
 
 // An OAuthClient represents the oauth client info
@@ -62,7 +62,7 @@ type IdentityToken struct {
 
 	// Information relative to the oauth application used to
 	// mint bearer's token.
-	OAuthApplication OAuthApplication `json:"oauthapplication,omitempty,omitzero"`
+	OAuthApplication OAuthApplication `json:"oauthApplication,omitempty,omitzero"`
 
 	// Information relative to the oauth client used to
 	// mint bearer's token.

--- a/pkgs/token/token.go
+++ b/pkgs/token/token.go
@@ -33,6 +33,13 @@ type OAuthApplication struct {
 	Name      string
 }
 
+// An OAuthClient represents the oauth client info
+// used to derive an IdentityToken.
+type OAuthClient struct {
+	ClientID  string `json:"clientID"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
 // An IdentityToken represents a normalized identity token.
 type IdentityToken struct {
 
@@ -56,6 +63,10 @@ type IdentityToken struct {
 	// Information relative to the oauth application used to
 	// mint bearer's token.
 	OAuthApplication OAuthApplication `json:"oauthapplication,omitempty,omitzero"`
+
+	// Information relative to the oauth client used to
+	// mint bearer's token.
+	OAuthClient OAuthClient `json:"oauthClient,omitempty,omitzero"`
 
 	jwt.RegisteredClaims
 }
@@ -152,6 +163,10 @@ func finalizeTokenParsing(idt *IdentityToken) error {
 			idt.OAuthApplication.Namespace = strings.TrimPrefix(c, "@oauthapp:namespace=")
 		case strings.HasPrefix(c, "@oauthapp:name="):
 			idt.OAuthApplication.Name = strings.TrimPrefix(c, "@oauthapp:name=")
+		case strings.HasPrefix(c, "@oauthclient:clientid="):
+			idt.OAuthClient.ClientID = strings.TrimPrefix(c, "@oauthclient:clientid=")
+		case strings.HasPrefix(c, "@oauthclient:namespace="):
+			idt.OAuthClient.Namespace = strings.TrimPrefix(c, "@oauthclient:namespace=")
 		}
 	}
 
@@ -218,6 +233,14 @@ func (t *IdentityToken) JWT(key crypto.PrivateKey, kid string, issuer string, au
 
 	if t.OAuthApplication.Name != "" {
 		t.Identity = append(t.Identity, fmt.Sprintf("@oauthapp:name=%s", t.OAuthApplication.Name))
+	}
+
+	if t.OAuthClient.ClientID != "" {
+		t.Identity = append(t.Identity, fmt.Sprintf("@oauthclient:clientid=%s", t.OAuthClient.ClientID))
+	}
+
+	if t.OAuthClient.Namespace != "" {
+		t.Identity = append(t.Identity, fmt.Sprintf("@oauthclient:namespace=%s", t.OAuthClient.Namespace))
 	}
 
 	t.Identity = append(t.Identity, fmt.Sprintf("@issuer=%s", t.Issuer))

--- a/pkgs/token/token_test.go
+++ b/pkgs/token/token_test.go
@@ -77,6 +77,10 @@ func TestParse(t *testing.T) {
 			Namespace: "/oauth/ns",
 			Name:      "oauthapp-name",
 		}
+		token1.OAuthClient = OAuthClient{
+			ClientID:  "oauthclient-id",
+			Namespace: "/oauthclient/ns",
+		}
 		token1.Identity = []string{
 			"org=a3s.com",
 			"orgunit=admin",
@@ -108,6 +112,8 @@ func TestParse(t *testing.T) {
 				"@oauthapp:id=oauthapp-id",
 				"@oauthapp:name=oauthapp-name",
 				"@oauthapp:namespace=/oauth/ns",
+				"@oauthclient:clientid=oauthclient-id",
+				"@oauthclient:namespace=/oauthclient/ns",
 				"@source:name=mysource",
 				"@source:namespace=/my/ns",
 				"@source:type=certificate",
@@ -126,6 +132,10 @@ func TestParse(t *testing.T) {
 				Namespace: "/oauth/ns",
 				Name:      "oauthapp-name",
 			})
+			So(token2.OAuthClient, ShouldResemble, OAuthClient{
+				ClientID:  "oauthclient-id",
+				Namespace: "/oauthclient/ns",
+			})
 			So(token2.Issuer, ShouldEqual, "iss")
 			So(token2.Audience, ShouldResemble, jwt.ClaimStrings{"aud"})
 			So(token2.ExpiresAt, ShouldResemble, token1.ExpiresAt)
@@ -135,6 +145,8 @@ func TestParse(t *testing.T) {
 				"@oauthapp:id=oauthapp-id",
 				"@oauthapp:name=oauthapp-name",
 				"@oauthapp:namespace=/oauth/ns",
+				"@oauthclient:clientid=oauthclient-id",
+				"@oauthclient:namespace=/oauthclient/ns",
 				"@source:name=mysource",
 				"@source:namespace=/my/ns",
 				"@source:type=certificate",
@@ -226,6 +238,10 @@ func TestParseUnverified(t *testing.T) {
 			Namespace: "/oauth/ns",
 			Name:      "oauthapp-name",
 		}
+		token1.OAuthClient = OAuthClient{
+			ClientID:  "oauthclient-id",
+			Namespace: "/oauthclient/ns",
+		}
 		token1.Identity = []string{
 			"org=a3s.com",
 			"orgunit=admin",
@@ -251,6 +267,10 @@ func TestParseUnverified(t *testing.T) {
 				Namespace: "/oauth/ns",
 				Name:      "oauthapp-name",
 			})
+			So(token2.OAuthClient, ShouldResemble, OAuthClient{
+				ClientID:  "oauthclient-id",
+				Namespace: "/oauthclient/ns",
+			})
 			So(token2.Issuer, ShouldEqual, "iss")
 			So(token2.Audience, ShouldResemble, jwt.ClaimStrings{"aud"})
 			So(token2.ExpiresAt, ShouldResemble, token1.ExpiresAt)
@@ -260,6 +280,8 @@ func TestParseUnverified(t *testing.T) {
 				"@oauthapp:id=oauthapp-id",
 				"@oauthapp:name=oauthapp-name",
 				"@oauthapp:namespace=/oauth/ns",
+				"@oauthclient:clientid=oauthclient-id",
+				"@oauthclient:namespace=/oauthclient/ns",
 				"@source:name=mysource",
 				"@source:namespace=/my/ns",
 				"@source:type=certificate",

--- a/pkgs/token/token_test.go
+++ b/pkgs/token/token_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"reflect"
@@ -54,6 +55,106 @@ func TestNewIdentityToken(t *testing.T) {
 		So(c.Map(), ShouldResemble, map[string][]string{})
 		c.Identity = []string{"a=b", "b=c", "b=d"}
 		So(c.Map(), ShouldResemble, map[string][]string{"a": {"b"}, "b": {"c", "d"}})
+	})
+}
+
+func TestIdentityToken_JSON(t *testing.T) {
+
+	Convey("Given a fully populated IdentityToken", t, func() {
+
+		token1 := &IdentityToken{
+			Identity: []string{"org=a3s.com", "orgunit=admin"},
+			Refresh:  true,
+			Opaque:   map[string]string{"key": "value"},
+			Restrictions: &permissions.Restrictions{
+				Namespace:   "/the/ns",
+				Networks:    []string{"10.0.0.0/24"},
+				Permissions: []string{"dog:get,put"},
+			},
+			Source: Source{
+				Type:      "certificate",
+				Namespace: "/my/ns",
+				Name:      "mysource",
+			},
+			OAuthApplication: OAuthApplication{
+				ID:        "oauthapp-id",
+				Namespace: "/oauth/ns",
+				Name:      "oauthapp-name",
+			},
+			OAuthClient: OAuthClient{
+				ClientID:  "oauthclient-id",
+				Namespace: "/oauthclient/ns",
+			},
+		}
+		token1.ID = "token-id"
+		token1.Issuer = "iss"
+		token1.Audience = jwt.ClaimStrings{"aud"}
+		token1.IssuedAt = jwt.NewNumericDate(time.Now().Truncate(time.Second))
+		token1.ExpiresAt = jwt.NewNumericDate(time.Now().Add(10 * time.Second).Truncate(time.Second))
+
+		Convey("Marshaling it should produce the expected JSON keys", func() {
+
+			d, err := json.Marshal(token1)
+			So(err, ShouldBeNil)
+
+			var m map[string]any
+			So(json.Unmarshal(d, &m), ShouldBeNil)
+
+			So(m, ShouldContainKey, "identity")
+			So(m, ShouldContainKey, "refresh")
+			So(m, ShouldContainKey, "opaque")
+			So(m, ShouldContainKey, "restrictions")
+			So(m, ShouldContainKey, "source")
+			So(m, ShouldContainKey, "oauthApplication")
+			So(m, ShouldContainKey, "oauthClient")
+			So(m, ShouldContainKey, "jti")
+			So(m, ShouldContainKey, "iss")
+			So(m, ShouldContainKey, "aud")
+			So(m, ShouldContainKey, "iat")
+			So(m, ShouldContainKey, "exp")
+
+			So(m["oauthClient"], ShouldResemble, map[string]any{
+				"clientID":  "oauthclient-id",
+				"namespace": "/oauthclient/ns",
+			})
+			So(m["oauthApplication"], ShouldResemble, map[string]any{
+				"ID":        "oauthapp-id",
+				"namespace": "/oauth/ns",
+				"name":      "oauthapp-name",
+			})
+		})
+
+		Convey("Marshaling then unmarshaling it should round trip all fields", func() {
+
+			d, err := json.Marshal(token1)
+			So(err, ShouldBeNil)
+
+			token2 := &IdentityToken{}
+			So(json.Unmarshal(d, token2), ShouldBeNil)
+
+			So(token2, ShouldResemble, token1)
+		})
+	})
+
+	Convey("Given an IdentityToken with zero-value OAuthApplication and OAuthClient", t, func() {
+
+		token1 := &IdentityToken{
+			Source: Source{
+				Type: "certificate",
+			},
+		}
+
+		Convey("Marshaling it should omit the oauthapplication and oauthClient keys", func() {
+
+			d, err := json.Marshal(token1)
+			So(err, ShouldBeNil)
+
+			var m map[string]any
+			So(json.Unmarshal(d, &m), ShouldBeNil)
+
+			So(m, ShouldNotContainKey, "oauthApplication")
+			So(m, ShouldNotContainKey, "oauthClient")
+		})
 	})
 }
 


### PR DESCRIPTION
Carry the originating OAuth client into the issued identity token so tokens minted through the OAuth flow retain the oauth client identity that produced them. This is useful to be able to apply policy and reporting based on the identity of the OAuth client.

This is the spiritual sibling to commit 33f25e9ecd3d ("token: stamp issued tokens with OAuth application identity") which applied the same logic to OAuth applications.